### PR TITLE
feat(tExtRef/subscribe): initial version

### DIFF
--- a/foundation/helpers.test.ts
+++ b/foundation/helpers.test.ts
@@ -1,4 +1,9 @@
-export function findElement(str: string, selector: string): Element | null {
+export function findElement(
+  str: string,
+  selector?: string
+): XMLDocument | Element | null {
+  if (!selector) return new DOMParser().parseFromString(str, "application/xml");
+
   return new DOMParser()
     .parseFromString(str, "application/xml")
     .querySelector(selector);

--- a/foundation/utils.ts
+++ b/foundation/utils.ts
@@ -27,6 +27,9 @@ export function isRemove(edit: Edit): edit is Remove {
     (edit as Insert).parent === undefined && (edit as Remove).node !== undefined
   );
 }
+export function isInsert(edit: Edit): edit is Insert {
+  return (edit as Insert).parent !== undefined;
+}
 
 /** Utility function to create element with `tagName` and its`attributes` */
 export function createElement(

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ export { lnInstGenerator } from "./generator/lnInstGenerator.js";
 export { UnsubscribeOptions } from "./tExtRef/unsubscribe.js";
 export { unsubscribe } from "./tExtRef/unsubscribe.js";
 export { extRefTypeRestrictions } from "./tExtRef/extRefTypeRestrictions.js";
+export { doesFcdaMeetExtRefRestrictions } from "./tExtRef/doesFcdaMeetExtRefRestrictions.js";
 
 export { fcdaBaseTypes } from "./tFCDA/fcdaBaseTypes.js";
 

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,8 @@ export { lnInstGenerator } from "./generator/lnInstGenerator.js";
 
 export { UnsubscribeOptions } from "./tExtRef/unsubscribe.js";
 export { unsubscribe } from "./tExtRef/unsubscribe.js";
+export { Connection } from "./tExtRef/subscribe.js";
+export { subscribe } from "./tExtRef/subscribe.js";
 export { extRefTypeRestrictions } from "./tExtRef/extRefTypeRestrictions.js";
 export { doesFcdaMeetExtRefRestrictions } from "./tExtRef/doesFcdaMeetExtRefRestrictions.js";
 

--- a/tExtRef/doesFcdaMeetExtRefRestrictions.spec.ts
+++ b/tExtRef/doesFcdaMeetExtRefRestrictions.spec.ts
@@ -1,0 +1,109 @@
+import { expect } from "chai";
+
+import { findElement } from "../foundation/helpers.test.js";
+import { publisherIED } from "./doesFcdaMeetExtRefRestrictions.testfiles.js";
+
+import { doesFcdaMeetExtRefRestrictions } from "./doesFcdaMeetExtRefRestrictions.js";
+
+const orphanFCDA = `<FCDA iedName="someIED" ldInst="someLdInst" lnClass="PTOC" lnInst="1" doName="Op" daName="general" fc="ST"/>`;
+const extRefXSWIPosDbPos = `<ExtRef pDO="Pos" pDA="stVal" pServT="GOOSE" pLN="XSWI"/>`;
+const extRefXSWIPosQ = `<ExtRef pDO="Pos" pDA="q" pServT="GOOSE" pLN="XSWI"/>`;
+const extRefPos = `<ExtRef pDO="Pos" />`;
+const extRefBehstVal = `<ExtRef pDO="Beh" pDA="stVal" />`;
+const extRefXSWIBehQ = `<ExtRef pDO="Beh" pDA="q" pServT="GOOSE" pLN="CSWI"/>`;
+const invalidExtRef = `<ExtRef pDO="someInvalidDO" pDA="Dbpos" pServT="GOOSE" pLN="XSWI"/>`;
+const invalidExtRef1 = `<ExtRef pDA="Dbpos" pServT="GOOSE" pLN="XSWI"/>`;
+const extRefCMVFLOAT32 = `<ExtRef pDO="A.phsA" pDA="cVal.mag.f" pServT="Report" pLN="MMXU"/>`;
+
+describe("Function compare FCDA basic types to ExtRef restrictions", () => {
+  it("is restrictive with invalid FCDA input", () => {
+    const fcda = findElement(orphanFCDA, "FCDA")!;
+    const extRef = findElement(extRefXSWIPosDbPos, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda)).to.be.false;
+  });
+
+  it("is restrictive with invalid ExtRef input", () => {
+    const fcda = findElement(orphanFCDA, "FCDA")!;
+    const extRef = findElement(invalidExtRef, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda)).to.be.false;
+  });
+
+  it("does not check with missing pDO", () => {
+    const fcda = findElement(orphanFCDA, "FCDA")!;
+    const extRef = findElement(invalidExtRef1, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda)).to.be.true;
+  });
+
+  it("is restrictive with missing controlServiceType", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="DPCdbpos"]`)!;
+    const extRef = findElement(extRefXSWIPosDbPos, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda)).to.be.false;
+  });
+
+  it("returns false with not matching pServT", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="DPCdbpos"]`)!;
+    const extRef = findElement(extRefXSWIPosDbPos, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda, "SMV")).to.be.false;
+  });
+
+  it("returns false with not matching pLN", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="DPCq"]`)!;
+    const extRef = findElement(extRefXSWIPosQ, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda, "GOOSE")).to.be.false;
+  });
+
+  it("returns false with not matching pDO", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="DPCq"]`)!;
+    const extRef = findElement(extRefXSWIBehQ, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda, "GOOSE")).to.be.false;
+  });
+
+  it("returns false with not matching cdc", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="USERENSnull"]`)!;
+    const extRef = findElement(extRefPos, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda, "GOOSE")).to.be.false;
+  });
+
+  it("returns false with not matching pDA", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="DPCdbpos"]`)!;
+    const extRef = findElement(extRefXSWIPosQ, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda, "GOOSE")).to.be.false;
+  });
+
+  it("returns false with not matching bType", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="USERENSstVal"]`)!;
+    const extRef = findElement(extRefBehstVal, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda, "GOOSE")).to.be.false;
+  });
+
+  it("returns true for matching types CMV/FLOAT32 ", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="CMVFLOAT32"]`)!;
+    const extRef = findElement(extRefCMVFLOAT32, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda, "Report")).to.be.true;
+  });
+
+  it("returns true for matching types DPC/Dbpos ", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="DPCdbpos"]`)!;
+    const extRef = findElement(extRefXSWIPosDbPos, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda, "GOOSE")).to.be.true;
+  });
+
+  it("returns true for matching types DPC/null ", () => {
+    const fcda = findElement(publisherIED, `FCDA[desc="DPCnull"]`)!;
+    const extRef = findElement(extRefPos, "ExtRef")!;
+
+    expect(doesFcdaMeetExtRefRestrictions(extRef, fcda)).to.be.true;
+  });
+});

--- a/tExtRef/doesFcdaMeetExtRefRestrictions.testfiles.ts
+++ b/tExtRef/doesFcdaMeetExtRefRestrictions.testfiles.ts
@@ -1,0 +1,304 @@
+export const publisherIED = `
+<SCL xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B" release="4">
+    <Header id="GOOSELaterBinding"/>
+    <IED name="GOOSE_Publisher" desc="GOOSE publisher" manufacturer="Dummy">
+        <AccessPoint name="AP1">
+            <Server>
+                <Authentication/>
+                <LDevice inst="QB2_Disconnector">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <DataSet name="GOOSE2sDataSet">
+                        <FCDA desc="invalidFCDA1"  prefix="" lnInst="1" daName="stVal" fc="ST"/>
+                        <FCDA desc="invalidFCDA2" ldInst="QB2_Disconnector" prefix="" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+                        <FCDA desc="invalidFCDA3" ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" daName="stVal" fc="ST"/>
+                        <FCDA desc="missingAnyLN" ldInst="QB2_Disconnector" lnClass="MMXU" lnInst="1" doName="A.phsA" daName="cVal.mag.f" fc="MX" />    
+                        <FCDA desc="invalidDoName" ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="invalidDoName" daName="q" fc="ST"/>
+                        <FCDA desc="invalidDaName" ldInst="Measurement" lnClass="MMXU" lnInst="1" doName="A.phsA" daName="cVal.mag.q" fc="MX" />    
+                        <FCDA desc="DPCq" ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+                        <FCDA desc="DPCdbpos" ldInst="QB2_Disconnector" prefix="" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+                        <FCDA desc="DPCnull" ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" fc="ST"/>
+                        <FCDA desc="USERENSnull" ldInst="QB2_Disconnector" prefix="" lnClass="USER" lnInst="1" doName="Pos" fc="ST"/>
+                        <FCDA desc="USERENSstVal" ldInst="QB2_Disconnector" prefix="" lnClass="USER" lnInst="1" doName="Beh" daName="stVal" fc="ST"/>
+                        <FCDA desc="SPSBool" ldInst="QB2_Disconnector" lnClass="CILO" lnInst="1" doName="EnaOpn" daName="stVal" fc="ST"/>
+                        <FCDA desc="LPLVis" ldInst="QB2_Disconnector" lnClass="LLN0" doName="NamPlt" daName="vendor" fc="DC"/>
+                        <FCDA desc="CMVFLOAT32" ldInst="Measurement" lnClass="MMXU" lnInst="1" doName="A.phsA" daName="cVal.mag.f" fc="MX" />    
+                        <FCDA desc="WYE" ldInst="Measurement" lnClass="MMXU" lnInst="1" doName="A" fc="MX" />    
+                    </DataSet>
+                </LN0>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+                <LN prefix="" lnClass="USER" inst="1" lnType="Dummy.USER"/>
+            </LDevice>
+            <LDevice inst="Measurement">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <DataSet name="Meas">
+                        </DataSet>
+                    <DataSet name="InvalidFCDAs">
+                        <FCDA ldInst="NonExistingLDinst" lnClass="MMXU" lnInst="1" doName="A.phsA" daName="cVal.mag.f" fc="MX" />
+                    </DataSet>
+                    <ReportControl name="someReport" datSet="Meas" />
+                </LN0>
+                <LN lnClass="MMXU" inst="1" lnType="Dummy.MMXU" />
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<DataTypeTemplates>
+    <LNodeType lnClass="XSWI" id="Dummy.XSWI" desc="Switch: one phase represenation">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+        <DO name="OpCnt" type="OpenSCD_INS_simple"/>
+        <DO name="Pos" type="OpenSCD_DPC_statusonly"/>
+        <DO name="BlkOpn" type="OpenSCD_SPC_statusonly"/>
+        <DO name="BlkCls" type="OpenSCD_SPC_statusonly"/>
+        <DO name="SwTyp" type="OpenSCD_ENS_SwTyp"/>
+    </LNodeType>
+    <LNodeType lnClass="XSWI" id="Dummy.USER" desc="Switch: one phase represenation">
+        <DO name="Beh" type="OpenSCD_ENS_Pos"/>
+        <DO name="Pos" type="OpenSCD_ENS_Pos"/>
+    </LNodeType>
+    <LNodeType lnClass="CSWI" id="Dummy.CSWI" desc="Switch control: no process bus(PB)">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+        <DO name="Pos" type="OpenSCD_DPC"/>
+    </LNodeType>
+    <LNodeType lnClass="CILO" id="Dummy.CILO" desc="Interlocking">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="EnaOpn" type="OpenSCD_SPS_simple"/>
+        <DO name="EnaCls" type="OpenSCD_SPS_simple"/>
+    </LNodeType>
+    <LNodeType lnClass="LLN0" id="Dummy.LLN0" desc="Logical device LN: parent">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+    </LNodeType>
+    <LNodeType lnClass="MMXU" id="Dummy.MMXU" desc="Logical device LN: parent">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+        <DO name="A" type="someWYE"/>
+    </LNodeType>
+    <DOType cdc="WYE" id="someWYE">
+        <SDO name="phsA" type="someMV"/>
+    </DOType>
+    <DOType cdc="CMV" id="someMV">
+        <DA fc="MX" dchg="true" name="cVal" bType="Struct" type="someVector"/>   
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_SwTyp">
+        <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="SwitchFunctionKind"/>
+        <DA fc="ST" qchg="true" name="q" bType="Quality"/>
+        <DA fc="ST" name="t" bType="Timestamp"/>
+    </DOType>
+    <DOType cdc="SPC" id="OpenSCD_SPC_statusonly">
+        <DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" dchg="true" type="OpenSCD_StatusOnly" fc="CF">
+            <Val>status-only</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="DPC" id="OpenSCD_DPC_statusonly">
+        <DA name="stVal" bType="Dbpos" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="OpenSCD_StatusOnly">
+            <Val>status-only</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="INS" id="OpenSCD_INS_simple">
+        <DA name="stVal" bType="INT32" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="DPC" id="OpenSCD_DPC">
+        <DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+        <DA name="stVal" bType="Dbpos" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+            <Val>sbo-with-enhanced-security</Val>
+        </DA>
+        <DA name="sboTimeout" bType="INT32U" fc="CF">
+            <Val>30000</Val>
+        </DA>
+        <DA name="operTimeout" bType="INT32U" fc="CF">
+            <Val>600</Val>
+        </DA>
+        <DA name="pulseConfig" bType="Struct" fc="CO" type="OpenSCD_PulseConfig"/>
+        <DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+        <DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+        <DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_Dbpos"/>
+    </DOType>
+    <DOType cdc="LPL" id="OpenSCD_LPL_noLD">
+        <DA name="vendor" bType="VisString255" fc="DC"/>
+        <DA name="swRev" bType="VisString255" fc="DC"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+        <DA name="configRev" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="SPS" id="OpenSCD_SPS_simple">
+        <DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="LPL" id="OpenSCD_LPL_LD">
+        <DA name="vendor" bType="VisString255" fc="DC"/>
+        <DA name="swRev" bType="VisString255" fc="DC"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+        <DA name="configRev" bType="VisString255" fc="DC"/>
+        <DA name="ldNs" bType="VisString255" fc="EX">
+            <Val>IEC 61850-7-4:2007B4</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_Health">
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="HealthKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_Beh">
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_Pos">
+        <DA name="stVal" bType="FLOAT32" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+    </DOType>
+    <DOType cdc="ENC" id="OpenSCD_ENC_Mod">
+        <DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+            <Val>sbo-with-enhanced-security</Val>
+        </DA>
+        <DA name="sboTimeout" bType="INT32U" fc="CF">
+            <Val>30000</Val>
+        </DA>
+        <DA name="operTimeout" bType="INT32U" fc="CF">
+            <Val>600</Val>
+        </DA>
+        <DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+        <DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+        <DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_BehaviourModeKind"/>
+    </DOType>
+    <DAType id="someVector">
+        <BDA name="mag" bType="Struct" type="someAnalogueValue"/>
+        <BDA name="ang" bType="Struct" type="someAnalogueValue"/>
+    </DAType>
+    <DAType id="someAnalogueValue">
+        <BDA name="f" bType="FLOAT32" />
+    </DAType>
+    <DAType id="someAnalogueValueINT32">
+        <BDA name="i" bType="INT32" />
+    </DAType>
+    <DAType id="OpenSCD_Cancel_Dbpos">
+        <BDA name="ctlVal" bType="Dbpos"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_OperSBOw_Dbpos">
+        <BDA name="ctlVal" bType="Dbpos"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <BDA name="Check" bType="Check"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_PulseConfig">
+        <BDA name="cmdQual" bType="Enum" type="OutputSignalKind"/>
+        <BDA name="onDur" bType="INT32U"/>
+        <BDA name="offDur" bType="INT32U"/>
+        <BDA name="numPls" bType="INT32U"/>
+    </DAType>
+    <DAType id="OpenSCD_Cancel_BehaviourModeKind">
+        <BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_OperSBOw_BehaviourModeKind">
+        <BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <BDA name="Check" bType="Check"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_Originator">
+        <BDA name="orCat" bType="Enum" type="OriginatorCategoryKind"/>
+        <BDA name="orIdent" bType="Octet64"/>
+    </DAType>
+    <EnumType id="SwitchFunctionKind">
+        <EnumVal ord="1">Load Break</EnumVal>
+        <EnumVal ord="2">Disconnector</EnumVal>
+        <EnumVal ord="3">Earthing Switch</EnumVal>
+        <EnumVal ord="4">High Speed Earthing Switch</EnumVal>
+    </EnumType>
+    <EnumType id="OpenSCD_StatusOnly">
+        <EnumVal ord="0">status-only</EnumVal>
+    </EnumType>
+    <EnumType id="OutputSignalKind">
+        <EnumVal ord="0">pulse</EnumVal>
+        <EnumVal ord="1">persistent</EnumVal>
+        <EnumVal ord="2">persistent-feedback</EnumVal>
+    </EnumType>
+    <EnumType id="HealthKind">
+        <EnumVal ord="1">Ok</EnumVal>
+        <EnumVal ord="2">Warning</EnumVal>
+        <EnumVal ord="3">Alarm</EnumVal>
+    </EnumType>
+    <EnumType id="CtlModelKind">
+        <EnumVal ord="0">status-only</EnumVal>
+        <EnumVal ord="1">direct-with-normal-security</EnumVal>
+        <EnumVal ord="2">sbo-with-normal-security</EnumVal>
+        <EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+        <EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
+    </EnumType>
+    <EnumType id="BehaviourModeKind">
+        <EnumVal ord="1">on</EnumVal>
+        <EnumVal ord="2">blocked</EnumVal>
+        <EnumVal ord="3">test</EnumVal>
+        <EnumVal ord="4">test/blocked</EnumVal>
+        <EnumVal ord="5">off</EnumVal>
+    </EnumType>
+    <EnumType id="OriginatorCategoryKind">
+        <EnumVal ord="0">not-supported</EnumVal>
+        <EnumVal ord="1">bay-control</EnumVal>
+        <EnumVal ord="2">station-control</EnumVal>
+        <EnumVal ord="3">remote-control</EnumVal>
+        <EnumVal ord="4">automatic-bay</EnumVal>
+        <EnumVal ord="5">automatic-station</EnumVal>
+        <EnumVal ord="6">automatic-remote</EnumVal>
+        <EnumVal ord="7">maintenance</EnumVal>
+        <EnumVal ord="8">process</EnumVal>
+    </EnumType>
+</DataTypeTemplates>
+</SCL>
+
+`;

--- a/tExtRef/doesFcdaMeetExtRefRestrictions.ts
+++ b/tExtRef/doesFcdaMeetExtRefRestrictions.ts
@@ -1,0 +1,53 @@
+import { fcdaBaseTypes } from "../tFCDA/fcdaBaseTypes.js";
+import { extRefTypeRestrictions } from "./extRefTypeRestrictions.js";
+
+/**
+ * This function checks if restrictions of an `ExtRef` element given by
+ * `pDO` and optionally by `pDA`, `pLN` and `pServT` are met by the FCDA/FCD
+ * @param extRef - The `ExtRef` element to be checked against
+ * @param data - The `FCDA` element to be checked
+ * @param controlBlockType - The control block type to check back with `pServT`
+ * @returns Whether the FCDA basic types meet the restrictions of the
+ * ExtRef element
+ */
+export function doesFcdaMeetExtRefRestrictions(
+  extRef: Element,
+  fcda: Element,
+  controlBlockType?: "GOOSE" | "Report" | "SMV" | "Poll"
+): boolean {
+  // Vendor does not provide data for the check so any FCDA meets restriction
+  if (!extRef.hasAttribute("pDO")) return true;
+
+  const fcdaTypes = fcdaBaseTypes(fcda);
+  const extRefSpec = extRefTypeRestrictions(extRef);
+
+  // Check cannot be performed assume restriction check to fail
+  if (!extRefSpec || !fcdaTypes) return false;
+
+  if (
+    extRef.getAttribute("pServT") &&
+    controlBlockType !== extRef.getAttribute("pServT")
+  )
+    return false;
+
+  if (
+    extRef.getAttribute("pLN") &&
+    extRef.getAttribute("pLN") !== fcda.getAttribute("lnClass")
+  )
+    return false;
+
+  if (
+    extRef.getAttribute("pDO") !== fcda.getAttribute("doName") ||
+    fcdaTypes.cdc !== extRefSpec.cdc
+  )
+    return false;
+
+  if (
+    extRef.getAttribute("pDA") &&
+    (extRef.getAttribute("pDA") !== fcda.getAttribute("daName") ||
+      fcdaTypes.bType !== extRefSpec.bType)
+  )
+    return false;
+
+  return true;
+}

--- a/tExtRef/extRefTypeRestrictions.spec.ts
+++ b/tExtRef/extRefTypeRestrictions.spec.ts
@@ -18,6 +18,10 @@ const pDOInValid = `<ExtRef
         intAddr="someIntAddr" 
         pDO="someStrangepDO" />`;
 
+const pDOInValid1 = `<ExtRef 
+        intAddr="someIntAddr" 
+        pDO="someStrangepDO" pDA="stVal" />`;
+
 const pDOandpDAValid1 = `<ExtRef 
         intAddr="someIntAddr" 
         pDO="AmpSv"
@@ -37,6 +41,10 @@ describe("A function to determine the CDC and bType though pXXX attributes", () 
   it("return undefined with missing pDO", () =>
     expect(extRefTypeRestrictions(findElement(unrestrictedExtRef, "ExtRef")!))
       .to.be.undefined);
+
+  it("return undefined with invalid pDO", () =>
+    expect(extRefTypeRestrictions(findElement(pDOInValid1, "ExtRef")!)).to.be
+      .undefined);
 
   describe("with pDO only given ExtRefs", () => {
     it("return correct CDC with a valid pDO", () =>

--- a/tExtRef/extRefTypeRestrictions.ts
+++ b/tExtRef/extRefTypeRestrictions.ts
@@ -21,8 +21,9 @@ export function extRefTypeRestrictions(
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dataObject = (dataObjects as any)[pDO];
+
   const cdc = dataObject?.cdc ?? null;
-  if (!pDA && !cdc) return;
+  if (!cdc) return;
   if (!pDA && cdc) return { cdc };
 
   const dataAttribute = dataObject.children[pDA!];

--- a/tExtRef/subscribe.spec.ts
+++ b/tExtRef/subscribe.spec.ts
@@ -1,0 +1,386 @@
+import { expect } from "chai";
+
+import { Insert, Update, isInsert, isUpdate } from "../foundation/utils.js";
+
+import { subscriptionEd2, subscriptionEd1 } from "./subscribe.testfiles.js";
+import { subscribe } from "./subscribe.js";
+import { findElement } from "../foundation/helpers.test.js";
+
+const docEd2 = findElement(subscriptionEd2) as XMLDocument;
+const docEd1 = findElement(subscriptionEd1) as XMLDocument;
+
+describe("Function to connect source data to sink elements (subscribe)", () => {
+  describe("with invalid inputs", () => {
+    it("invalid sink element LDevice", () => {
+      const controlBlock = docEd1.querySelector(`GSEControl[desc="goose1"]`)!;
+      const fcda = docEd1.querySelector(`FCDA[desc="goose1q"]`)!;
+      const sink = docEd1.querySelector(`LDevice[inst="Earth_Switch"]`)!;
+
+      const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+      expect(actions.length).to.equal(0);
+    });
+
+    it("invalid sink element missing ExtRef intAddr", () => {
+      const controlBlock = docEd2.querySelector(`GSEControl[desc="goose1"]`)!;
+      const fcda = docEd2.querySelector(`FCDA[desc="goose1q"]`)!;
+      const sink = docEd2.querySelector(`ExtRef[desc="missingIntAddr"]`)!;
+
+      const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+      expect(actions.length).to.equal(0);
+    });
+
+    it("invalid sink element subscriber later binding ExtRef", () => {
+      const controlBlock = docEd2.querySelector(`GSEControl[desc="goose1"]`)!;
+      const fcda = docEd2.querySelector(`FCDA[desc="goose1q"]`)!;
+      const sink = docEd2.querySelector(`ExtRef[desc="subscribedExtRef"]`)!;
+
+      const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+      expect(actions.length).to.equal(0);
+    });
+
+    it("invalid source.fcda element", () => {
+      const fcda = docEd1.querySelector(`FCDA[desc="missingDoName"]`)!;
+      const sink = docEd1.querySelector(`Inputs`)!;
+
+      const actions = subscribe([{ sink, source: { fcda } }]);
+      expect(actions.length).to.equal(0);
+    });
+
+    it("invalid with orphan FCDA", () => {
+      const source = docEd1.querySelector(`FCDA[desc="goose1q"]`)!;
+      const orphanFcda = source.cloneNode(true) as Element;
+      const sink = docEd2.querySelector(`Inputs`)!;
+
+      expect(
+        subscribe([{ sink, source: { fcda: orphanFcda } }]).length
+      ).to.equal(0);
+    });
+  });
+
+  describe("with edition 1 projects", () => {
+    it("return update action for later binding type ExtRef ", () => {
+      const controlBlock = docEd1.querySelector(`GSEControl[desc="goose1"]`)!;
+      const fcda = docEd1.querySelector(`FCDA[desc="goose1q"]`)!;
+      const sink = docEd1.querySelector(`ExtRef[intAddr="Pos;CSWI1/Pos/q"]`)!;
+
+      const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+      expect(actions.length).to.equal(1);
+      expect(actions[0]).to.satisfies(isUpdate);
+      expect((actions[0] as Update).element).to.equal(sink);
+      expect((actions[0] as Update).attributes).to.deep.equal({
+        iedName: "GOOSE_Publisher",
+        ldInst: "QB1_Disconnector",
+        prefix: "",
+        lnClass: "CSWI",
+        lnInst: "1",
+        doName: "Pos",
+        daName: "q",
+        fc: "ST",
+      });
+    });
+
+    it("returns insert action for non later binding type subscription", () => {
+      const controlBlock = docEd1.querySelector(`GSEControl[desc="goose1"]`)!;
+      const fcda = docEd1.querySelector(`FCDA[desc="goose1q"]`)!;
+      const sink = docEd1.querySelector(`Inputs`)!;
+
+      const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+      expect(actions.length).to.equal(1);
+      expect(actions[0]).to.satisfies(isInsert);
+      expect(((actions[0] as Insert).parent as Element).tagName).to.equal(
+        "Inputs"
+      );
+      expect(((actions[0] as Insert).node as Element).tagName).to.equal(
+        "ExtRef"
+      );
+      expect(((actions[0] as Insert).reference as Element).tagName).to.equal(
+        "ExtRef"
+      );
+
+      const extRef = (actions[0] as Insert).node as Element;
+      expect(extRef.getAttribute("iedName")).to.equal("GOOSE_Publisher");
+      expect(extRef.getAttribute("ldInst")).to.equal("QB1_Disconnector");
+      expect(extRef.getAttribute("prefix")).to.equal("");
+      expect(extRef.getAttribute("lnClass")).to.equal("CSWI");
+      expect(extRef.getAttribute("lnInst")).to.equal("1");
+      expect(extRef.getAttribute("doName")).to.equal("Pos");
+      expect(extRef.getAttribute("daName")).to.equal("q");
+      expect(extRef.getAttribute("fc")).to.equal("ST");
+      expect(extRef.hasAttribute("serviceType")).to.be.false;
+      expect(extRef.hasAttribute("srcLDInst")).to.be.false;
+      expect(extRef.hasAttribute("srcPrefix")).to.be.false;
+      expect(extRef.hasAttribute("srcLNClass")).to.be.false;
+      expect(extRef.hasAttribute("srcLNInst")).to.be.false;
+      expect(extRef.hasAttribute("srcCBName")).to.be.false;
+    });
+  });
+
+  describe("with edition 2 and upward projects", () => {
+    describe("for later binding type subscription", () => {
+      it("checks for invalid pLN to lnClass", () => {
+        const controlBlock = docEd2.querySelector("ReportControl")!;
+        const fcda = docEd2.querySelector(`DataSet[name="Meas"] > FCDA`)!;
+        const source = { fcda, controlBlock };
+
+        const sink = docEd2.querySelector(`ExtRef[intAddr="invalAnalogue1"]`)!;
+        expect(subscribe([{ sink, source }]).length).to.equal(0);
+      });
+
+      it("checks for invalid pDO to doName", () => {
+        const controlBlock = docEd2.querySelector("ReportControl")!;
+        const fcda = docEd2.querySelector(`DataSet[name="Meas"] > FCDA`)!;
+        const source = { fcda, controlBlock };
+
+        const sink = docEd2.querySelector(`ExtRef[intAddr="invalAnalogue1"]`)!;
+        expect(subscribe([{ sink, source }]).length).to.equal(0);
+      });
+
+      it("checks for invalid pDA to daName", () => {
+        const controlBlock = docEd2.querySelector("ReportControl")!;
+        const fcda = docEd2.querySelector(`DataSet[name="Meas"] > FCDA`)!;
+        const source = { fcda, controlBlock };
+
+        const sink = docEd2.querySelector(`ExtRef[intAddr="invalAnalogue1"]`)!;
+        expect(subscribe([{ sink, source }]).length).to.equal(0);
+      });
+
+      it("checks for invalid pServT to controlBlock.tagName", () => {
+        const controlBlock = docEd2.querySelector("GSEControl")!;
+        const fcda = docEd2.querySelector(`DataSet[name="Meas"] > FCDA`)!;
+        const source = { fcda, controlBlock };
+
+        const sink = docEd2.querySelector(`ExtRef[intAddr="validAnalogue"]`)!;
+        expect(subscribe([{ sink, source }]).length).to.equal(0);
+      });
+
+      it("is strict with incorrect FCDA definition", () => {
+        const fcda = docEd2.querySelector(`FCDA[ldInst="NonExistingLDinst"]`)!;
+        const sink = docEd2.querySelector(`ExtRef[intAddr="validAnalogue"]`)!;
+
+        expect(subscribe([{ sink, source: { fcda } }]).length).to.equal(0);
+      });
+
+      it("returns no update action with failing SPS/BOOLEAN check", () => {
+        const controlBlock = docEd2.querySelector(`GSEControl[name="GOOSE1"]`)!;
+        const fcda = docEd2.querySelector(`FCDA[desc="goose1q"]`)!;
+        const sink = docEd2.querySelector(`ExtRef[intAddr="restrictExtRef"]`)!;
+
+        const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+        expect(actions.length).to.equal(0);
+      });
+
+      it("returns no update action with failing CMV/FLOAT32 check ", () => {
+        const controlBlock = docEd2.querySelector(`ReportControl`)!;
+        const fcda = docEd2.querySelector(` DataSet[name="Meas"] > FCDA`)!;
+        const sink = docEd2.querySelector(`ExtRef[intAddr="wrongAnalogue"]`)!;
+
+        const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+        expect(actions.length).to.equal(0);
+      });
+
+      it("returns update action with passing SPC/BOOLEAN check", () => {
+        const controlBlock = docEd2.querySelector(`GSEControl[name="GOOSE1"]`)!;
+        const fcda = docEd2.querySelector(`FCDA[desc="goose1stVal"]`)!;
+        const sink = docEd2.querySelector(`ExtRef[intAddr="restrictExtRef"]`)!;
+
+        const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+        expect(actions.length).to.equal(1);
+      });
+
+      it("returns update action with passing CMV/FLOAT32 check", () => {
+        const controlBlock = docEd2.querySelector(` ReportControl`)!;
+        const fcda = docEd2.querySelector(` DataSet[name="Meas"] > FCDA`)!;
+        const sink = docEd2.querySelector(`ExtRef[intAddr="validAnalogue"]`)!;
+
+        const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+        expect(actions.length).to.equal(1);
+      });
+
+      it("return update action with srcxxx attributes with controlBlock set", () => {
+        const controlBlock = docEd2.querySelector(`GSEControl[name="GOOSE1"]`)!;
+        const fcda = docEd2.querySelector(`FCDA[desc="goose1stVal"]`)!;
+        const sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] ExtRef[intAddr="Pos;CSWI1/Pos/stVal"]`
+        )!;
+
+        const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+        expect(actions.length).to.equal(1);
+        expect(actions[0]).to.satisfies(isUpdate);
+        expect((actions[0] as Update).element).to.equal(sink);
+        expect((actions[0] as Update).attributes).to.deep.equal({
+          iedName: "GOOSE_Publisher",
+          ldInst: "QB1_Disconnector",
+          prefix: "",
+          lnClass: "CSWI",
+          lnInst: "1",
+          doName: "Pos",
+          daName: "stVal",
+          fc: "ST",
+          srcLDInst: "QB2_Disconnector",
+          srcPrefix: "",
+          srcLNClass: "LLN0",
+          srcLNInst: null,
+          srcCBName: "GOOSE1",
+          serviceType: "GOOSE",
+        });
+      });
+
+      it("return update action without srcXXX attributes with controlBlock set", () => {
+        const controlBlock = undefined;
+        const fcda = docEd2.querySelector(`FCDA[desc="goose1stVal"]`)!;
+        const sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] ExtRef[intAddr="Pos;CSWI1/Pos/stVal"]`
+        )!;
+
+        const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+        expect(actions.length).to.equal(1);
+        expect(actions[0]).to.satisfies(isUpdate);
+        expect((actions[0] as Update).element).to.equal(sink);
+        expect((actions[0] as Update).attributes).to.deep.equal({
+          iedName: "GOOSE_Publisher",
+          ldInst: "QB1_Disconnector",
+          prefix: "",
+          lnClass: "CSWI",
+          lnInst: "1",
+          doName: "Pos",
+          daName: "stVal",
+          fc: "ST",
+          srcLDInst: null,
+          srcPrefix: null,
+          srcLNClass: null,
+          srcLNInst: null,
+          srcCBName: null,
+          serviceType: null,
+        });
+      });
+    });
+
+    describe("for non later binding type subscription", () => {
+      it("return insert action to add ExtRef", () => {
+        const controlBlock = docEd2.querySelector(`GSEControl[name="GOOSE1"]`)!;
+        const fcda = docEd2.querySelector(`FCDA[desc="goose1q"]`)!;
+        const sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] LDevice[inst="Earth_Switch"] LN[lnClass="XSWI"]`
+        )!;
+
+        const actions = subscribe([{ sink, source: { fcda, controlBlock } }]);
+        expect(actions.length).to.equal(2);
+        expect(actions[0]).to.satisfies(isInsert);
+        expect(((actions[0] as Insert).parent as Element).tagName).to.equal(
+          "LN"
+        );
+        expect(((actions[0] as Insert).node as Element).tagName).to.equal(
+          "Inputs"
+        );
+        expect((actions[0] as Insert).reference).to.equal(null);
+
+        const extRef = (actions[1] as Insert).node as Element;
+        expect(extRef.getAttribute("iedName")).to.equal("GOOSE_Publisher");
+        expect(extRef.getAttribute("ldInst")).to.equal("QB1_Disconnector");
+        expect(extRef.getAttribute("prefix")).to.equal("");
+        expect(extRef.getAttribute("lnClass")).to.equal("CSWI");
+        expect(extRef.getAttribute("lnInst")).to.equal("1");
+        expect(extRef.getAttribute("doName")).to.equal("Pos");
+        expect(extRef.getAttribute("daName")).to.equal("q");
+        expect(extRef.getAttribute("fc")).to.equal("ST");
+        expect(extRef.getAttribute("srcLDInst")).to.equal("QB2_Disconnector");
+        expect(extRef.getAttribute("srcPrefix")).to.be.equal("");
+        expect(extRef.getAttribute("srcLNClass")).to.equal("LLN0");
+        expect(extRef.getAttribute("srcLNInst")).to.be.null;
+        expect(extRef.getAttribute("srcCBName")).to.equal("GOOSE1");
+        expect(extRef.getAttribute("serviceType")).to.equal("GOOSE");
+      });
+
+      it("makes sure to create as many inputs as needed", () => {
+        const controlBlock = undefined;
+        let fcda = docEd2.querySelector(
+          `IED[name="GOOSE_Publisher"] DataSet[name="GOOSE2sDataSet"] > FCDA[daName="stVal"]`
+        )!;
+        let sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] LDevice[inst="Earth_Switch"] LN[lnClass="XSWI"]`
+        )!;
+        const extRef3 = { sink, source: { fcda, controlBlock } };
+
+        fcda = docEd2.querySelector(
+          `IED[name="GOOSE_Publisher"] DataSet[name="GOOSE2sDataSet"] > FCDA[daName="q"]`
+        )!;
+        sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] LDevice[inst="Earth_Switch"] LN[lnClass="XSWI"]`
+        )!;
+        const extRef4 = { sink, source: { fcda, controlBlock } };
+
+        const actions = subscribe([extRef3, extRef4]);
+        expect(actions.length).to.equal(3);
+        expect(actions[0]).to.satisfies(isInsert);
+        expect(actions[1]).to.satisfies(isInsert);
+        expect(actions[2]).to.satisfies(isInsert);
+      });
+    });
+
+    describe("for a combination of both subscription types", () => {
+      it("allows multiple subscriptions at once", () => {
+        let controlBlock: Element | undefined =
+          docEd2.querySelector(`SampledValueControl`)!;
+        let fcda = docEd2.querySelector(
+          `IED[name="GOOSE_Publisher"] DataSet[name="SamplVal"] > FCDA[daName="instMag.i"]`
+        )!;
+        let sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] LDevice[inst="Earth_Switch"] ExtRef[intAddr="someTCTRinstMag"]`
+        )!;
+        const extRef1 = {
+          sink,
+          source: { fcda, controlBlock },
+        };
+
+        fcda = docEd2.querySelector(
+          `IED[name="GOOSE_Publisher"] DataSet[name="SamplVal"] > FCDA[daName="q"]`
+        )!;
+        sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] LDevice[inst="Earth_Switch"] ExtRef[intAddr="someTCTRq"]`
+        )!;
+        const extRef2 = { sink, source: { fcda, controlBlock } };
+
+        controlBlock = undefined;
+        fcda = docEd2.querySelector(
+          `IED[name="GOOSE_Publisher"] DataSet[name="GOOSE2sDataSet"] > FCDA[daName="stVal"]`
+        )!;
+        sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] LDevice[inst="Earth_Switch"] LN[lnClass="XSWI"]`
+        )!;
+        const extRef3 = { sink, source: { fcda, controlBlock } };
+
+        fcda = docEd2.querySelector(
+          `IED[name="GOOSE_Publisher"] DataSet[name="GOOSE2sDataSet"] > FCDA[daName="q"]`
+        )!;
+        sink = docEd2.querySelector(
+          `IED[name="GOOSE_Subscriber"] LDevice[inst="Earth_Switch"] LN[lnClass="XSWI"]`
+        )!;
+        const extRef4 = { sink, source: { fcda, controlBlock } };
+
+        const actions = subscribe([extRef1, extRef2, extRef3, extRef4]);
+        expect(actions.length).to.equal(5);
+        expect(actions[0]).to.satisfies(isInsert);
+        expect(actions[1]).to.satisfies(isUpdate);
+        expect((actions[1] as Update).attributes).to.deep.equal({
+          iedName: "GOOSE_Publisher",
+          ldInst: "SampledValue",
+          prefix: "L1",
+          lnClass: "TCTR",
+          lnInst: "1",
+          doName: "AmpSv",
+          daName: "instMag.i",
+          fc: "MX",
+          srcLDInst: "SampledValue",
+          srcPrefix: "",
+          srcLNClass: "LLN0",
+          srcLNInst: null,
+          srcCBName: "someSmv",
+          serviceType: "SMV",
+        });
+        expect(actions[2]).to.satisfies(isUpdate);
+        expect(actions[3]).to.satisfies(isInsert);
+        expect(actions[4]).to.satisfies(isInsert);
+      });
+    });
+  });
+});

--- a/tExtRef/subscribe.testfiles.ts
+++ b/tExtRef/subscribe.testfiles.ts
@@ -1,0 +1,1016 @@
+export const subscriptionEd2 = `
+<SCL xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B" release="4">
+    <Header id="GOOSELaterBinding"/>
+<Communication>
+    <SubNetwork name="StationBus" desc="" type="8-MMS">
+        <BitRate unit="b/s" multiplier="M">100</BitRate>
+        <ConnectedAP iedName="GOOSE_Subscriber1" apName="AP1"/>
+        <ConnectedAP iedName="GOOSE_Subscriber2" apName="AP1"/>
+        <ConnectedAP iedName="GOOSE_Subscriber3" apName="AP1"/>
+        <ConnectedAP iedName="GOOSE_Subscriber4" apName="AP1"/>
+        <ConnectedAP iedName="GOOSE_Publisher" apName="AP1">
+            <GSE ldInst="QB2_Disconnector" cbName="GOOSE2">
+                <Address>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-01</P>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0002</P>
+                </Address>
+                <MinTime unit="s" multiplier="m">10</MinTime>
+                <MaxTime unit="s" multiplier="m">1000</MaxTime>
+            </GSE>
+            <GSE ldInst="QB2_Disconnector" cbName="GOOSE1">
+                <Address>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-00</P>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0001</P>
+                </Address>
+                <MinTime unit="s" multiplier="m">10</MinTime>
+                <MaxTime unit="s" multiplier="m">1000</MaxTime>
+            </GSE>
+        </ConnectedAP>
+        <ConnectedAP iedName="GOOSE_Publisher2" apName="AP1">
+            <GSE ldInst="QB2_Disconnector" cbName="GOOSE2">
+                <Address>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-03</P>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0003</P>
+                </Address>
+                <MinTime unit="s" multiplier="m">10</MinTime>
+                <MaxTime unit="s" multiplier="m">1000</MaxTime>
+            </GSE>
+            <GSE ldInst="QB2_Disconnector" cbName="GOOSE1">
+                <Address>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-04</P>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0004</P>
+                </Address>
+                <MinTime unit="s" multiplier="m">10</MinTime>
+                <MaxTime unit="s" multiplier="m">1000</MaxTime>
+            </GSE>
+        </ConnectedAP>
+    </SubNetwork>
+</Communication>
+<IED name="GOOSE_Subscriber" desc="GOOSE subscriber" manufacturer="Dummy">
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <Inputs>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+                    </Inputs>
+                </LN0>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO">
+                    <Inputs>
+                        <ExtRef desc="missingIntAddr"/>
+                        <ExtRef desc="subscribedExtRef" intAddr="someIntAddr" iedName="GOOSE_Publisher" />
+                        <ExtRef intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input"/>
+                        <ExtRef intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input"/>
+                    </Inputs>
+                </LN>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI">
+                    <Inputs>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input2"/>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input2"/>
+                        <ExtRef intAddr="restrictExtRef" desc="Restricted To Pos" pLN="CSWI" pDO="Pos" pDA="stVal"/>
+                    </Inputs>
+                </LN>
+                <LN prefix="L1" lnClass="TCTR" lnInst="1" lnType="Dummy.TCTR">
+                    <ExtRef intAddr="someTCTRinstMag" pLN="TCTR" pDO="AmpSv" pDA="instMag.i" pServT="SMV" />
+                    <ExtRef intAddr="someTCTRq" pLN="TCTR" pDO="AmpSv" pDA="q" pServT="SMV" />
+                </LN>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Subscriber1" desc="GOOSE subscriber" manufacturer="Dummy">
+    <Services>
+        <SupSubscription maxGo="4" maxSv="0"/>
+    </Services>
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <Inputs>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+                        <ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+                        <ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+                    </Inputs>
+                </LN0>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO">
+                    <Inputs>
+                        <ExtRef intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input"/>
+                        <ExtRef intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input"/>
+                    </Inputs>
+                </LN>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI">
+                    <Inputs>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input2"/>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input2"/>
+                        <ExtRef intAddr="someRestrictedExtRef" desc="Restricted To Pos" pLN="CSWI" pDO="Pos" pDA="stVal"/>
+                        <ExtRef intAddr="validAnalogue" pLN="MMXU" pDO="A.phsA" pDA="cVal.mag.f" pServT="Report"/>
+                        <ExtRef intAddr="wrongAnalogue" pLN="MMXU" pDO="A.phsA" pDA="cVal.mag.f" pServT="SMV" />
+                        <ExtRef intAddr="invalAnalogue1" pLN="PTOC" pDO="A.phsA" pDA="cVal.mag.f" pServT="Report" />
+                        <ExtRef intAddr="invalAnalogue2" pLN="MMXU" pDO="A.phsB" pDA="cVal.mag.f" pServT="Report" />
+                        <ExtRef intAddr="invalAnalogue3" pLN="MMXU" pDO="A.phsA" pDA="cVal.mag.i" pServT="Report" />
+                    </Inputs>
+                </LN>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+                <LN lnClass="MMXU" inst="1" lnType="Dummy.MMXU" />
+            </LDevice>
+            <LDevice inst="SV_supervision">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS">
+                    <DOI name="GoCBRef">
+                        <DAI name="setSrcRef">
+                            <Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2</Val>
+                        </DAI>
+                    </DOI>
+                </LN>
+                <LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS">
+                    <Private type="OpenSCD.create"/>
+                    <DOI name="GoCBRef">
+                        <DAI name="setSrcRef">
+                            <Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE2</Val>
+                        </DAI>
+                    </DOI>
+                </LN>
+                <LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS">
+                    <Private type="OpenSCD.create"/>
+                    <DOI name="GoCBRef">
+                        <DAI name="setSrcRef">
+                            <Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE1</Val>
+                        </DAI>
+                    </DOI>
+                </LN>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Subscriber2" desc="GOOSE subscriber" manufacturer="Dummy">
+    <Services>
+        <SupSubscription maxGo="4" maxSv="0"/>
+    </Services>
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="SV_supervision">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS"/>
+                <LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS"/>
+                <LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS"/>
+                <LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Subscriber3" desc="GOOSE subscriber" manufacturer="Dummy">
+    <Services>
+        <SupSubscription maxGo="4" maxSv="0"/>
+    </Services>
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="SV_supervision">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS1"/>
+                <LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS1">
+                    <DOI name="SomethingLikeGoCBRef">
+                        <DAI name="setSrcRef" valImport="true" valKind="RO">
+                            <Val>The supervision instance to rule them all!</Val>
+                        </DAI>
+                    </DOI>
+                </LN>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Subscriber4" desc="GOOSE subscriber" manufacturer="Dummy">
+    <Services>
+        <SupSubscription maxGo="4" maxSv="0"/>
+    </Services>
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="SV_supervision">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS2"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Subscriber5" desc="GOOSE subscriber" manufacturer="Dummy">
+    <Services>
+        <SupSubscription maxGo="4" maxSv="0"/>
+    </Services>
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="GOOSE_supervision">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS1">
+                    <DOI name="GoCBRef">
+                        <DAI name="setSrcRef" valImport="true" valKind="RO">
+                            <Val>The One True Original</Val>
+                        </DAI>
+                    </DOI>
+                </LN>
+                <LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS2"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Subscriber6" desc="GOOSE subscriber" manufacturer="Dummy">
+    <Services>
+        <SupSubscription maxGo="4" maxSv="0"/>
+    </Services>
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="GOOSE_supervision">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS1">
+                    <DOI name="GoCBRef">
+                        <DAI name="setSrcRef" valImport="true" valKind="Conf">
+                            <Val>The One True Original</Val>
+                        </DAI>
+                    </DOI>
+                </LN>
+                <LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS2"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Subscriber7" desc="GOOSE subscriber" manufacturer="Dummy">
+    <Services>
+        <SupSubscription maxGo="4" maxSv="0"/>
+    </Services>
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="GOOSE_supervision">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS1">
+                    <DOI name="GoCBRef">
+                        <DAI name="setSrcRef" valImport="true" valKind="Conf">
+                            <Val></Val>
+                        </DAI>
+                    </DOI>
+                </LN>
+                <LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS2"/>
+                <LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS2"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Publisher" desc="GOOSE publisher" manufacturer="Dummy">
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="QB2_Disconnector">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <DataSet name="GOOSE2sDataSet">
+                        <FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+                        <FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+                    </DataSet>
+                    <DataSet name="GOOSE1sDataSet">
+                        <FCDA desc="goose1stVal" ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+                        <FCDA desc="goose1q" ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+                    </DataSet>
+                    <GSEControl name="GOOSE2" type="GOOSE" appID="GOOSE2" confRev="1" datSet="GOOSE2sDataSet"/>
+                    <GSEControl name="GOOSE1" type="GOOSE" appID="GOOSE1" confRev="1" datSet="GOOSE1sDataSet"/>
+                </LN0>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="QB1_Disconnector">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="Measurement">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <DataSet name="Meas">
+                        <FCDA ldInst="Measurement" lnClass="MMXU" lnInst="1" doName="A.phsA" daName="cVal.mag.f" fc="MX" />
+                    </DataSet>
+                    <DataSet name="InvalidFCDAs">
+                        <FCDA ldInst="NonExistingLDinst" lnClass="MMXU" lnInst="1" doName="A.phsA" daName="cVal.mag.f" fc="MX" />
+                    </DataSet>
+                    <ReportControl name="someReport" datSet="Meas" />
+                </LN0>
+                <LN lnClass="MMXU" inst="1" lnType="Dummy.MMXU" />
+            </LDevice>
+            <LDevice inst="SampledValue">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <DataSet name="SamplVal">
+                        <FCDA ldInst="SampledValue" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX" />
+                        <FCDA ldInst="SampledValue" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX" />
+                    </DataSet>
+                    <SampledValueControl name="someSmv" datSet="SampVal" />
+                </LN0>
+                <LN prefix="L1" lnClass="TCTR" inst="1" lnType="Dummy.TCTR" />
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Publisher2" desc="GOOSE publisher" manufacturer="Dummy">
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="QB2_Disconnector">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <DataSet name="GOOSE2sDataSet">
+                        <FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+                        <FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+                    </DataSet>
+                    <DataSet name="GOOSE1sDataSet">
+                        <FCDA ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+                        <FCDA ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+                    </DataSet>
+                    <GSEControl name="GOOSE2" type="GOOSE" appID="GOOSE2" confRev="1" datSet="GOOSE2sDataSet"/>
+                    <GSEControl name="GOOSE1" type="GOOSE" appID="GOOSE1" confRev="1" datSet="GOOSE1sDataSet"/>
+                </LN0>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="QB1_Disconnector">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<DataTypeTemplates>
+    <LNodeType lnClass="LGOS" id="Dummy.LGOS">
+        <DO name="GoCBRef" type="Dummy.ORG"/>
+        <DO name="St" type="OpenSCD_SPS_simple"/>
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+    </LNodeType>
+    <LNodeType lnClass="LGOS" id="Dummy.LGOS1">
+        <DO name="GoCBRef" type="Dummy.ORG1"/>
+        <DO name="SomethingLikeGoCBRef" type="Dummy.ORG1"/>
+        <DO name="St" type="OpenSCD_SPS_simple"/>
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+    </LNodeType>
+    <LNodeType lnClass="LGOS" id="Dummy.LGOS2">
+        <DO name="GoCBRef" type="Dummy.ORG2"/>
+        <DO name="St" type="OpenSCD_SPS_simple"/>
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+    </LNodeType>
+    <LNodeType lnClass="XSWI" id="Dummy.XSWI" desc="Switch: one phase represenation">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+        <DO name="OpCnt" type="OpenSCD_INS_simple"/>
+        <DO name="Pos" type="OpenSCD_DPC_statusonly"/>
+        <DO name="BlkOpn" type="OpenSCD_SPC_statusonly"/>
+        <DO name="BlkCls" type="OpenSCD_SPC_statusonly"/>
+        <DO name="SwTyp" type="OpenSCD_ENS_SwTyp"/>
+    </LNodeType>
+    <LNodeType lnClass="CSWI" id="Dummy.CSWI" desc="Switch control: no process bus(PB)">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+        <DO name="Pos" type="OpenSCD_DPC"/>
+    </LNodeType>
+    <LNodeType lnClass="CILO" id="Dummy.CILO" desc="Interlocking">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="EnaOpn" type="OpenSCD_SPS_simple"/>
+        <DO name="EnaCls" type="OpenSCD_SPS_simple"/>
+    </LNodeType>
+    <LNodeType lnClass="LLN0" id="Dummy.LLN0" desc="Logical device LN: parent">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+    </LNodeType>
+    <LNodeType lnClass="MMXU" id="Dummy.MMXU" desc="Logical device LN: parent">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+        <DO name="A" type="someWYE"/>
+    </LNodeType>
+    <LNodeType lnClass="TCTR" id="Dummy.TCTR" desc="Current Transformer">
+        <DO name="Beh" type="ENS_Beh" desc="OpenSCD_ENS_Beh"/>
+        <DO name="AmpSv" type="Dummy.SAV"/>
+    </LNodeType>
+    <DOType cdc="SAV" id="Dummy.SAV" desc="Sampled value">
+        <DA fc="MX" name="instMag" bType="Struct" type="someAnalogueValueINT32"/>
+        <DA fc="MX" qchg="true" name="q" bType="Quality"/>
+    </DOType>
+    <DOType cdc="WYE" id="someWYE">
+        <SDO name="phsA" type="someMV"/>
+    </DOType>
+    <DOType cdc="CMV" id="someMV">
+        <DA fc="MX" dchg="true" name="cVal" bType="Struct" type="someVector"/>   
+    </DOType>
+    <DOType cdc="ORG" id="Dummy.ORG">
+        <DA name="setSrcRef" bType="ObjRef" dchg="true" valKind="RO" valImport="true" fc="SP"/>
+    </DOType>
+    <DOType cdc="ORG" id="Dummy.ORG1">
+        <DA name="setSrcRef" bType="ObjRef" dchg="true" valKind="Conf" valImport="true" fc="SP"/>
+    </DOType>
+    <DOType cdc="ORG" id="Dummy.ORG2">
+        <DA name="setSrcRef" bType="ObjRef" dchg="true" fc="SP"/>
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_SwTyp">
+        <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="SwitchFunctionKind"/>
+        <DA fc="ST" qchg="true" name="q" bType="Quality"/>
+        <DA fc="ST" name="t" bType="Timestamp"/>
+    </DOType>
+    <DOType cdc="SPC" id="OpenSCD_SPC_statusonly">
+        <DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" dchg="true" type="OpenSCD_StatusOnly" fc="CF">
+            <Val>status-only</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="DPC" id="OpenSCD_DPC_statusonly">
+        <DA name="stVal" bType="Dbpos" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="OpenSCD_StatusOnly">
+            <Val>status-only</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="INS" id="OpenSCD_INS_simple">
+        <DA name="stVal" bType="INT32" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="DPC" id="OpenSCD_DPC">
+        <DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+        <DA name="stVal" bType="Dbpos" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+            <Val>sbo-with-enhanced-security</Val>
+        </DA>
+        <DA name="sboTimeout" bType="INT32U" fc="CF">
+            <Val>30000</Val>
+        </DA>
+        <DA name="operTimeout" bType="INT32U" fc="CF">
+            <Val>600</Val>
+        </DA>
+        <DA name="pulseConfig" bType="Struct" fc="CO" type="OpenSCD_PulseConfig"/>
+        <DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+        <DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+        <DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_Dbpos"/>
+    </DOType>
+    <DOType cdc="LPL" id="OpenSCD_LPL_noLD">
+        <DA name="vendor" bType="VisString255" fc="DC"/>
+        <DA name="swRev" bType="VisString255" fc="DC"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+        <DA name="configRev" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="SPS" id="OpenSCD_SPS_simple">
+        <DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="LPL" id="OpenSCD_LPL_LD">
+        <DA name="vendor" bType="VisString255" fc="DC"/>
+        <DA name="swRev" bType="VisString255" fc="DC"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+        <DA name="configRev" bType="VisString255" fc="DC"/>
+        <DA name="ldNs" bType="VisString255" fc="EX">
+            <Val>IEC 61850-7-4:2007B4</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_Health">
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="HealthKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_Beh">
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+    </DOType>
+    <DOType cdc="ENC" id="OpenSCD_ENC_Mod">
+        <DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+            <Val>sbo-with-enhanced-security</Val>
+        </DA>
+        <DA name="sboTimeout" bType="INT32U" fc="CF">
+            <Val>30000</Val>
+        </DA>
+        <DA name="operTimeout" bType="INT32U" fc="CF">
+            <Val>600</Val>
+        </DA>
+        <DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+        <DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+        <DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_BehaviourModeKind"/>
+    </DOType>
+    <DAType id="someVector">
+        <BDA name="mag" bType="Struct" type="someAnalogueValue"/>
+        <BDA name="ang" bType="Struct" type="someAnalogueValue"/>
+    </DAType>
+    <DAType id="someAnalogueValue">
+        <BDA name="f" bType="FLOAT32" />
+    </DAType>
+    <DAType id="someAnalogueValueINT32">
+        <BDA name="i" bType="INT32" />
+    </DAType>
+    <DAType id="OpenSCD_Cancel_Dbpos">
+        <BDA name="ctlVal" bType="Dbpos"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_OperSBOw_Dbpos">
+        <BDA name="ctlVal" bType="Dbpos"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <BDA name="Check" bType="Check"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_PulseConfig">
+        <BDA name="cmdQual" bType="Enum" type="OutputSignalKind"/>
+        <BDA name="onDur" bType="INT32U"/>
+        <BDA name="offDur" bType="INT32U"/>
+        <BDA name="numPls" bType="INT32U"/>
+    </DAType>
+    <DAType id="OpenSCD_Cancel_BehaviourModeKind">
+        <BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_OperSBOw_BehaviourModeKind">
+        <BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <BDA name="Check" bType="Check"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_Originator">
+        <BDA name="orCat" bType="Enum" type="OriginatorCategoryKind"/>
+        <BDA name="orIdent" bType="Octet64"/>
+    </DAType>
+    <EnumType id="SwitchFunctionKind">
+        <EnumVal ord="1">Load Break</EnumVal>
+        <EnumVal ord="2">Disconnector</EnumVal>
+        <EnumVal ord="3">Earthing Switch</EnumVal>
+        <EnumVal ord="4">High Speed Earthing Switch</EnumVal>
+    </EnumType>
+    <EnumType id="OpenSCD_StatusOnly">
+        <EnumVal ord="0">status-only</EnumVal>
+    </EnumType>
+    <EnumType id="OutputSignalKind">
+        <EnumVal ord="0">pulse</EnumVal>
+        <EnumVal ord="1">persistent</EnumVal>
+        <EnumVal ord="2">persistent-feedback</EnumVal>
+    </EnumType>
+    <EnumType id="HealthKind">
+        <EnumVal ord="1">Ok</EnumVal>
+        <EnumVal ord="2">Warning</EnumVal>
+        <EnumVal ord="3">Alarm</EnumVal>
+    </EnumType>
+    <EnumType id="CtlModelKind">
+        <EnumVal ord="0">status-only</EnumVal>
+        <EnumVal ord="1">direct-with-normal-security</EnumVal>
+        <EnumVal ord="2">sbo-with-normal-security</EnumVal>
+        <EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+        <EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
+    </EnumType>
+    <EnumType id="BehaviourModeKind">
+        <EnumVal ord="1">on</EnumVal>
+        <EnumVal ord="2">blocked</EnumVal>
+        <EnumVal ord="3">test</EnumVal>
+        <EnumVal ord="4">test/blocked</EnumVal>
+        <EnumVal ord="5">off</EnumVal>
+    </EnumType>
+    <EnumType id="OriginatorCategoryKind">
+        <EnumVal ord="0">not-supported</EnumVal>
+        <EnumVal ord="1">bay-control</EnumVal>
+        <EnumVal ord="2">station-control</EnumVal>
+        <EnumVal ord="3">remote-control</EnumVal>
+        <EnumVal ord="4">automatic-bay</EnumVal>
+        <EnumVal ord="5">automatic-station</EnumVal>
+        <EnumVal ord="6">automatic-remote</EnumVal>
+        <EnumVal ord="7">maintenance</EnumVal>
+        <EnumVal ord="8">process</EnumVal>
+    </EnumType>
+</DataTypeTemplates>
+</SCL>
+
+`;
+
+export const subscriptionEd1 = `
+<SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+    <Header id="GOOSELaterBinding"/>
+<Communication>
+    <SubNetwork name="StationBus" desc="" type="8-MMS">
+        <BitRate unit="b/s" multiplier="M">100</BitRate>
+        <ConnectedAP iedName="GOOSE_Subscriber1" apName="AP1"/>
+        <ConnectedAP iedName="GOOSE_Subscriber2" apName="AP1"/>
+        <ConnectedAP iedName="GOOSE_Subscriber3" apName="AP1"/>
+        <ConnectedAP iedName="GOOSE_Subscriber4" apName="AP1"/>
+        <ConnectedAP iedName="GOOSE_Publisher" apName="AP1">
+            <GSE ldInst="QB2_Disconnector" cbName="GOOSE2">
+                <Address>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-01</P>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0002</P>
+                </Address>
+                <MinTime unit="s" multiplier="m">10</MinTime>
+                <MaxTime unit="s" multiplier="m">1000</MaxTime>
+            </GSE>
+            <GSE ldInst="QB2_Disconnector" cbName="GOOSE1">
+                <Address>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-00</P>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0001</P>
+                </Address>
+                <MinTime unit="s" multiplier="m">10</MinTime>
+                <MaxTime unit="s" multiplier="m">1000</MaxTime>
+            </GSE>
+        </ConnectedAP>
+        <ConnectedAP iedName="GOOSE_Publisher2" apName="AP1">
+            <GSE ldInst="QB2_Disconnector" cbName="GOOSE2">
+                <Address>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-03</P>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0003</P>
+                </Address>
+                <MinTime unit="s" multiplier="m">10</MinTime>
+                <MaxTime unit="s" multiplier="m">1000</MaxTime>
+            </GSE>
+            <GSE ldInst="QB2_Disconnector" cbName="GOOSE1">
+                <Address>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-04</P>
+                    <P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0004</P>
+                </Address>
+                <MinTime unit="s" multiplier="m">10</MinTime>
+                <MaxTime unit="s" multiplier="m">1000</MaxTime>
+            </GSE>
+        </ConnectedAP>
+    </SubNetwork>
+</Communication>
+<IED name="GOOSE_Subscriber" desc="GOOSE subscriber" manufacturer="Dummy">
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="Earth_Switch">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <Inputs>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" />
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" />
+                    </Inputs>
+                </LN0>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO">
+                    <Inputs>
+                        <ExtRef intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input"/>
+                        <ExtRef intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input"/>
+                    </Inputs>
+                </LN>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI">
+                    <Inputs>
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" />
+                        <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input2"/>
+                    </Inputs>
+                </LN>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<IED name="GOOSE_Publisher" desc="GOOSE publisher" manufacturer="Dummy">
+    <AccessPoint name="AP1">
+        <Server>
+            <Authentication/>
+            <LDevice inst="QB2_Disconnector">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+                    <DataSet name="GOOSE2sDataSet">
+                        <FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+                        <FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+                        <FCDA desc="missingDoName" ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" daName="q" fc="ST"/>
+                    </DataSet>
+                    <DataSet name="GOOSE1sDataSet">
+                        <FCDA ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+                        <FCDA desc="goose1q" ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+                    </DataSet>
+                    <GSEControl desc="goose2" name="GOOSE2" type="GOOSE" appID="GOOSE2" confRev="1" datSet="GOOSE2sDataSet"/>
+                    <GSEControl desc="goose1" name="GOOSE1" type="GOOSE" appID="GOOSE1" confRev="1" datSet="GOOSE1sDataSet"/>
+                </LN0>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+            <LDevice inst="QB1_Disconnector">
+                <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+                <LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+                <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+                <LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+            </LDevice>
+        </Server>
+    </AccessPoint>
+</IED>
+<DataTypeTemplates>
+    <LNodeType lnClass="XSWI" id="Dummy.XSWI" desc="Switch: one phase represenation">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+        <DO name="OpCnt" type="OpenSCD_INS_simple"/>
+        <DO name="Pos" type="OpenSCD_DPC_statusonly"/>
+        <DO name="BlkOpn" type="OpenSCD_SPC_statusonly"/>
+        <DO name="BlkCls" type="OpenSCD_SPC_statusonly"/>
+        <DO name="SwTyp" type="OpenSCD_ENS_SwTyp"/>
+    </LNodeType>
+    <LNodeType lnClass="CSWI" id="Dummy.CSWI" desc="Switch control: no process bus(PB)">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+        <DO name="Pos" type="OpenSCD_DPC"/>
+    </LNodeType>
+    <LNodeType lnClass="CILO" id="Dummy.CILO" desc="Interlocking">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+        <DO name="EnaOpn" type="OpenSCD_SPS_simple"/>
+        <DO name="EnaCls" type="OpenSCD_SPS_simple"/>
+    </LNodeType>
+    <LNodeType lnClass="LLN0" id="Dummy.LLN0" desc="Logical device LN: parent">
+        <DO name="Mod" type="OpenSCD_ENC_Mod"/>
+        <DO name="Beh" type="OpenSCD_ENS_Beh"/>
+        <DO name="Health" type="OpenSCD_ENS_Health"/>
+        <DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+        <DO name="LocKey" type="OpenSCD_SPS_simple"/>
+        <DO name="Loc" type="OpenSCD_SPS_simple"/>
+    </LNodeType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_SwTyp">
+        <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="SwitchFunctionKind"/>
+        <DA fc="ST" qchg="true" name="q" bType="Quality"/>
+        <DA fc="ST" name="t" bType="Timestamp"/>
+    </DOType>
+    <DOType cdc="SPC" id="OpenSCD_SPC_statusonly">
+        <DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" dchg="true" type="OpenSCD_StatusOnly" fc="CF">
+            <Val>status-only</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="DPC" id="OpenSCD_DPC_statusonly">
+        <DA name="stVal" bType="Dbpos" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="OpenSCD_StatusOnly">
+            <Val>status-only</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="INS" id="OpenSCD_INS_simple">
+        <DA name="stVal" bType="INT32" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="DPC" id="OpenSCD_DPC">
+        <DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+        <DA name="stVal" bType="Dbpos" dchg="true" fc="ST" type="BehaviourModeKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+            <Val>sbo-with-enhanced-security</Val>
+        </DA>
+        <DA name="sboTimeout" bType="INT32U" fc="CF">
+            <Val>30000</Val>
+        </DA>
+        <DA name="operTimeout" bType="INT32U" fc="CF">
+            <Val>600</Val>
+        </DA>
+        <DA name="pulseConfig" bType="Struct" fc="CO" type="OpenSCD_PulseConfig"/>
+        <DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+        <DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+        <DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_Dbpos"/>
+    </DOType>
+    <DOType cdc="LPL" id="OpenSCD_LPL_noLD">
+        <DA name="vendor" bType="VisString255" fc="DC"/>
+        <DA name="swRev" bType="VisString255" fc="DC"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+        <DA name="configRev" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="SPS" id="OpenSCD_SPS_simple">
+        <DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+    </DOType>
+    <DOType cdc="LPL" id="OpenSCD_LPL_LD">
+        <DA name="vendor" bType="VisString255" fc="DC"/>
+        <DA name="swRev" bType="VisString255" fc="DC"/>
+        <DA name="d" bType="VisString255" fc="DC"/>
+        <DA name="configRev" bType="VisString255" fc="DC"/>
+        <DA name="ldNs" bType="VisString255" fc="EX">
+            <Val>IEC 61850-7-4:2007B4</Val>
+        </DA>
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_Health">
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="HealthKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+    </DOType>
+    <DOType cdc="ENS" id="OpenSCD_ENS_Beh">
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+    </DOType>
+    <DOType cdc="ENC" id="OpenSCD_ENC_Mod">
+        <DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+        <DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+        <DA name="q" bType="Quality" qchg="true" fc="ST"/>
+        <DA name="t" bType="Timestamp" fc="ST"/>
+        <DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+            <Val>sbo-with-enhanced-security</Val>
+        </DA>
+        <DA name="sboTimeout" bType="INT32U" fc="CF">
+            <Val>30000</Val>
+        </DA>
+        <DA name="operTimeout" bType="INT32U" fc="CF">
+            <Val>600</Val>
+        </DA>
+        <DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+        <DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+        <DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_BehaviourModeKind"/>
+    </DOType>
+    <DAType id="OpenSCD_Cancel_Dbpos">
+        <BDA name="ctlVal" bType="Dbpos"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_OperSBOw_Dbpos">
+        <BDA name="ctlVal" bType="Dbpos"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <BDA name="Check" bType="Check"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_PulseConfig">
+        <BDA name="cmdQual" bType="Enum" type="OutputSignalKind"/>
+        <BDA name="onDur" bType="INT32U"/>
+        <BDA name="offDur" bType="INT32U"/>
+        <BDA name="numPls" bType="INT32U"/>
+    </DAType>
+    <DAType id="OpenSCD_Cancel_BehaviourModeKind">
+        <BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_OperSBOw_BehaviourModeKind">
+        <BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+        <BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+        <BDA name="ctlNum" bType="INT8U"/>
+        <BDA name="T" bType="Timestamp"/>
+        <BDA name="Test" bType="BOOLEAN"/>
+        <BDA name="Check" bType="Check"/>
+        <ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+    </DAType>
+    <DAType id="OpenSCD_Originator">
+        <BDA name="orCat" bType="Enum" type="OriginatorCategoryKind"/>
+        <BDA name="orIdent" bType="Octet64"/>
+    </DAType>
+    <EnumType id="SwitchFunctionKind">
+        <EnumVal ord="1">Load Break</EnumVal>
+        <EnumVal ord="2">Disconnector</EnumVal>
+        <EnumVal ord="3">Earthing Switch</EnumVal>
+        <EnumVal ord="4">High Speed Earthing Switch</EnumVal>
+    </EnumType>
+    <EnumType id="OpenSCD_StatusOnly">
+        <EnumVal ord="0">status-only</EnumVal>
+    </EnumType>
+    <EnumType id="OutputSignalKind">
+        <EnumVal ord="0">pulse</EnumVal>
+        <EnumVal ord="1">persistent</EnumVal>
+        <EnumVal ord="2">persistent-feedback</EnumVal>
+    </EnumType>
+    <EnumType id="HealthKind">
+        <EnumVal ord="1">Ok</EnumVal>
+        <EnumVal ord="2">Warning</EnumVal>
+        <EnumVal ord="3">Alarm</EnumVal>
+    </EnumType>
+    <EnumType id="CtlModelKind">
+        <EnumVal ord="0">status-only</EnumVal>
+        <EnumVal ord="1">direct-with-normal-security</EnumVal>
+        <EnumVal ord="2">sbo-with-normal-security</EnumVal>
+        <EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+        <EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
+    </EnumType>
+    <EnumType id="BehaviourModeKind">
+        <EnumVal ord="1">on</EnumVal>
+        <EnumVal ord="2">blocked</EnumVal>
+        <EnumVal ord="3">test</EnumVal>
+        <EnumVal ord="4">test/blocked</EnumVal>
+        <EnumVal ord="5">off</EnumVal>
+    </EnumType>
+    <EnumType id="OriginatorCategoryKind">
+        <EnumVal ord="0">not-supported</EnumVal>
+        <EnumVal ord="1">bay-control</EnumVal>
+        <EnumVal ord="2">station-control</EnumVal>
+        <EnumVal ord="3">remote-control</EnumVal>
+        <EnumVal ord="4">automatic-bay</EnumVal>
+        <EnumVal ord="5">automatic-station</EnumVal>
+        <EnumVal ord="6">automatic-remote</EnumVal>
+        <EnumVal ord="7">maintenance</EnumVal>
+        <EnumVal ord="8">process</EnumVal>
+    </EnumType>
+</DataTypeTemplates>
+</SCL>
+
+`;

--- a/tExtRef/subscribe.ts
+++ b/tExtRef/subscribe.ts
@@ -1,0 +1,238 @@
+import { Insert, Update, createElement } from "../foundation/utils.js";
+import { getReference } from "../general/getReference.js";
+
+import { doesFcdaMeetExtRefRestrictions } from "./doesFcdaMeetExtRefRestrictions.js";
+
+const serviceTypes: Partial<Record<string, "Report" | "GOOSE" | "SMV">> = {
+  ReportControl: "Report",
+  GSEControl: "GOOSE",
+  SampledValueControl: "SMV",
+};
+
+export type Connection = {
+  /** Can be `LN0`, `LN`, `Inputs` or `ExtRef` */
+  sink: Element;
+  source: {
+    /** `FCDA` element with or without `daName` */
+    fcda: Element;
+    /** `ReportControl`, `GSEControl`, `SampledValueControl` */
+    controlBlock?: Element;
+  };
+};
+
+function srcAttributes(controlBlock?: Element): {
+  srcLDInst: string | null;
+  srcPrefix: string | null;
+  srcLNClass: string | null;
+  srcLNInst: string | null;
+  srcCBName: string | null;
+  serviceType: "Report" | "GOOSE" | "SMV" | null;
+} | null {
+  const srcLDInst =
+    controlBlock?.closest("LDevice")?.getAttribute("inst") || null;
+  const srcPrefix =
+    controlBlock?.closest("LN0,LN")?.getAttribute("prefix") || "";
+  const srcLNClass =
+    controlBlock?.closest("LN0,LN")?.getAttribute("lnClass") || null;
+  const srcLNInst =
+    controlBlock?.closest("LN0,LN")?.getAttribute("inst") || null;
+  const srcCBName = controlBlock?.getAttribute("name") || null;
+
+  if (
+    !controlBlock ||
+    !serviceTypes[controlBlock.tagName] ||
+    !srcLDInst ||
+    !srcLNClass ||
+    !srcCBName
+  )
+    return {
+      srcLDInst: null,
+      srcPrefix: null,
+      srcLNClass: null,
+      srcLNInst: null,
+      srcCBName: null,
+      serviceType: null,
+    };
+
+  return {
+    srcLDInst,
+    srcPrefix,
+    srcLNClass,
+    srcLNInst,
+    srcCBName,
+    serviceType: serviceTypes[controlBlock.tagName]!,
+  };
+}
+
+function getDataAttributes(fcda: Element): {
+  iedName: string;
+  ldInst: string;
+  prefix: string | null;
+  lnClass: string;
+  lnInst: string | null;
+  doName: string;
+  daName: string | null;
+  fc: string;
+} | null {
+  const sourceIed = fcda.closest("IED");
+  const iedName = sourceIed?.getAttribute("name");
+  const [ldInst, prefix, lnClass, lnInst, doName, daName, fc] = [
+    "ldInst",
+    "prefix",
+    "lnClass",
+    "lnInst",
+    "doName",
+    "daName",
+    "fc",
+  ].map((attr) => fcda.getAttribute(attr));
+
+  if (!sourceIed || !iedName || !ldInst || !lnClass || !doName || !fc)
+    return null;
+
+  return {
+    iedName,
+    ldInst,
+    prefix,
+    lnClass,
+    lnInst,
+    doName,
+    daName,
+    fc,
+  };
+}
+
+function createSubscribeAction(
+  connection: Connection,
+  parent: Element
+): Update | Insert | null {
+  const doc = connection.sink.ownerDocument;
+  const fcda = connection.source.fcda;
+  const controlBlock = connection.source.controlBlock;
+
+  const isEd1 = !doc.querySelector("SCL")?.getAttribute("version");
+
+  const ed1Attributes = getDataAttributes(fcda);
+  if (!ed1Attributes) return null;
+
+  const ed2Attributes = {
+    ...ed1Attributes,
+    ...srcAttributes(controlBlock),
+  };
+
+  if (connection.sink.tagName === "ExtRef" && isEd1)
+    return {
+      element: connection.sink,
+      attributes: ed1Attributes,
+    };
+
+  if (connection.sink.tagName === "ExtRef" && !isEd1)
+    return {
+      element: connection.sink,
+      attributes: ed2Attributes,
+    };
+
+  const reference = getReference(parent, "ExtRef");
+
+  if (connection.sink.tagName !== "ExtRef" && isEd1) {
+    const extRef = createElement(doc, "ExtRef", ed1Attributes);
+    return { parent, node: extRef, reference };
+  }
+
+  const extRef = createElement(doc, "ExtRef", ed2Attributes);
+  return { parent, node: extRef, reference };
+}
+
+function createSubscribeActions(
+  connections: Connection[]
+): (Insert | Update)[] {
+  const inputActions: Insert[] = [];
+
+  const extRefActions = connections
+    .map((option) => {
+      const parent = option.sink;
+
+      // no Inputs child yet in anyLN element
+      if (
+        (parent.tagName === "LN" || parent.tagName === "LN0") &&
+        !inputActions.some((insert) => insert.parent === parent)
+      ) {
+        const inputs = createElement(parent.ownerDocument, "Inputs", {});
+        const action = createSubscribeAction(option!, inputs);
+        if (action)
+          inputActions.push({
+            parent,
+            node: inputs,
+            reference: getReference(parent, "Inputs"),
+          });
+
+        return action;
+      }
+
+      // there is an Input already in anyLn
+      if (
+        (parent.tagName === "LN" || parent.tagName === "LN0") &&
+        inputActions.some((insert) => insert.parent === parent)
+      ) {
+        const inputs = inputActions.find((insert) => insert.parent === parent)!
+          .node as Element;
+        return createSubscribeAction(option!, inputs);
+      }
+
+      return createSubscribeAction(option!, parent);
+    })
+    .filter((action) => action) as (Insert | Update)[];
+
+  return [...inputActions, ...extRefActions];
+}
+
+function invalidSink(sink: Element): boolean {
+  if (sink.tagName === "ExtRef")
+    return !sink.getAttribute("intAddr") || !!sink.getAttribute("iedName");
+
+  return !(
+    sink.tagName === "LN" ||
+    sink.tagName === "LN0" ||
+    sink.tagName === "Inputs"
+  );
+}
+
+function validSubscribeConditions(connection: Connection): boolean {
+  if (invalidSink(connection.sink)) return false;
+
+  //TODO: check connection via Communication section
+
+  const fcda = connection.source.fcda;
+  const controlBlock = connection.source.controlBlock;
+  const serviceType = controlBlock
+    ? serviceTypes[controlBlock.tagName]
+    : undefined;
+  if (
+    connection.sink.tagName === "ExtRef" &&
+    !doesFcdaMeetExtRefRestrictions(connection.sink, fcda, serviceType)
+  )
+    return false;
+
+  return true;
+}
+
+/**
+ * A function to subscribe [[`source`]] to [[`sink`]].
+ * @param sink - Can be `LN0`, `LN` and `Inputs`
+ * for non-later-binding type of subscription and `ExtRef` with `intAddr`
+ * for later binding type subscription.
+ * @param source.fcda - `FCDA` element
+ * @param source.controlBlock - The control block carrying the [[`source.fcda`]]
+ * @returns An array of actions to do a valid subscription
+ */
+export function subscribe(connections: Connection[]): (Insert | Update)[] {
+  const validConnections = connections.filter(
+    validSubscribeConditions
+  ) as Connection[];
+
+  const extRefActions = createSubscribeActions(validConnections);
+
+  return [
+    ...extRefActions,
+    //TODO: ...insertSubscriptionSupervisions(extRefActions),
+  ];
+}


### PR DESCRIPTION
Closes #9 with an initial `subscribe` function that supports:

- check for valid source and sink definitions
- later binding
- srcXXX attributes
- check for ExtRef restrictions

and does not:
- add subscription supervision
- physical connection
