### PR TITLE
fix(foundation/nsd): Improve nsd import in dependent libraries

### DIFF
--- a/tExtRef/extRefTypeRestrictions.ts
+++ b/tExtRef/extRefTypeRestrictions.ts
@@ -1,4 +1,6 @@
-import dataObjects from "../foundation/nsd.json";
+const dataObjects = await fetch(
+  new URL("../foundation/nsd.json", import.meta.url)
+).then((res) => res.json());
 
 /**
  * This function returns the common data class `CDC` of the

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,6 @@
   },
   "files": [
     "./index.ts",
+    "./foundation/nsd.json"
   ],
 }

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -5,7 +5,7 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
   /** Test files to run */
   files: '**/*.spec.ts',
 
-  plugins: [esbuildPlugin({ ts: true, json: true })],
+  plugins: [esbuildPlugin({ ts: true })],
 
   /** Resolve bare module imports */
   nodeResolve: {


### PR DESCRIPTION
Closes #28

This almost works but I can't get the tests to pass:

```
tExtRef/extRefTypeRestrictions.spec.ts:

 🚧 Browser logs:
      SyntaxError: Unexpected token 'v', "var NamPlt"... is not valid JSON

 ❌ Could not import your test module. Check the browser logs or open the browser in debug mode for more information. 
```

I think this is because "somehow" a sourcemap is included with this json file which I must still examine.
