### PR TITLE
feat(tLN/removeSubscriptionSupervision)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+import { canRemoveSubscriptionSupervision } from "./tLN/canRemoveSubscriptionSupervision.js";
+
 export { Update } from "./foundation/utils.js";
 export { Insert } from "./foundation/utils.js";
 export { Remove } from "./foundation/utils.js";
@@ -17,6 +19,9 @@ export { SubscribeOptions } from "./tExtRef/subscribe.js";
 export { subscribe } from "./tExtRef/subscribe.js";
 export { extRefTypeRestrictions } from "./tExtRef/extRefTypeRestrictions.js";
 export { doesFcdaMeetExtRefRestrictions } from "./tExtRef/doesFcdaMeetExtRefRestrictions.js";
+
+export { removeSubscriptionSupervision } from "./tLN/removeSubscriptionSupervision.js";
+export { canRemoveSubscriptionSupervision } from "./tLN/canRemoveSubscriptionSupervision.js";
 
 export { fcdaBaseTypes } from "./tFCDA/fcdaBaseTypes.js";
 

--- a/tExtRef/unsubscribe.spec.ts
+++ b/tExtRef/unsubscribe.spec.ts
@@ -5,7 +5,14 @@ import {
   withSubscriptionSupervision,
 } from "./unsubscribe.testfiles.js";
 
-import { Remove, Update, isRemove, isUpdate } from "../foundation/utils.js";
+import {
+  Insert,
+  Remove,
+  Update,
+  isInsert,
+  isRemove,
+  isUpdate,
+} from "../foundation/utils.js";
 import { unsubscribe } from "./unsubscribe.js";
 import { findElement } from "../foundation/helpers.test.js";
 
@@ -99,17 +106,25 @@ describe("Function allowing to unsubscribe multiple external references", () => 
       'LN[lnClass="LGOS"][inst="2"]'
     );
 
-    expect(actions.length).to.equal(5);
+    expect(actions.length).to.equal(7);
     expect(actions[0]).to.satisfies(isRemove);
     expect((actions[0] as Remove).node).to.equal(extRefs[0]);
     expect(actions[1]).to.satisfies(isRemove);
     expect((actions[1] as Remove).node).to.equal(extRefs[1]);
     expect(actions[2]).to.satisfies(isUpdate);
     expect((actions[2] as Update).element).to.equal(extRefs[2]);
-    expect(actions[3]).to.satisfies(isRemove);
-    expect((actions[3] as Remove).node).to.equal(doi);
-    expect(actions[4]).to.satisfies(isRemove);
-    expect((actions[4] as Remove).node).to.equal(ln);
+
+    expect(isRemove(actions[3])).to.be.true;
+    expect((<Remove>actions[3]).node.nodeName).to.be.equal("Val");
+    expect((<Remove>actions[3]).node.textContent).to.be.equal(
+      "srcIEDsomeLDInst/LLN0.someGse"
+    );
+
+    expect(isInsert(actions[4])).to.be.true;
+    expect((<Insert>actions[4]).node.nodeName).to.be.equal("Val");
+    expect((<Insert>actions[4]).node.textContent).to.be.equal("");
+    expect((<Insert>actions[4]).parent.nodeName).to.be.equal("DAI");
+    expect((<Insert>actions[4]).reference).to.be.null;
   });
 
   it("with ignoreSupervision do not remove subscription LGOS supervision", () => {
@@ -162,15 +177,26 @@ describe("Function allowing to unsubscribe multiple external references", () => 
     );
     const actions = unsubscribe(extRefs);
 
-    expect(actions.length).to.equal(4);
+    expect(actions.length).to.equal(5);
+
     expect(actions[0]).to.satisfies(isRemove);
     expect((actions[0] as Remove).node).to.equal(extRefs[0]);
     expect(actions[1]).to.satisfies(isRemove);
     expect((actions[1] as Remove).node).to.equal(extRefs[1]);
     expect(actions[2]).to.satisfies(isRemove);
     expect((actions[2] as Remove).node).to.equal(extRefs[1].parentElement);
-    expect(actions[3]).to.satisfies(isRemove);
-    expect((actions[3] as Remove).node).to.equal(doi);
+
+    expect(isRemove(actions[3])).to.be.true;
+    expect((<Remove>actions[3]).node.nodeName).to.be.equal("Val");
+    expect((<Remove>actions[3]).node.textContent).to.be.equal(
+      "srcIEDsomeLDInst/LLN0.someSmv"
+    );
+
+    expect(isInsert(actions[4])).to.be.true;
+    expect((<Insert>actions[4]).node.nodeName).to.be.equal("Val");
+    expect((<Insert>actions[4]).node.textContent).to.be.equal("");
+    expect((<Insert>actions[4]).parent.nodeName).to.be.equal("DAI");
+    expect((<Insert>actions[4]).reference).to.be.null;
   });
 
   it("with ignoreSupervision do not remove subscription LGOS supervision", () => {

--- a/tExtRef/unsubscribe.ts
+++ b/tExtRef/unsubscribe.ts
@@ -1,4 +1,4 @@
-import { Remove, Update } from "../foundation/utils.js";
+import { Insert, Remove, Update } from "../foundation/utils.js";
 
 import { removeInputs } from "../tInputs/removeInputs.js";
 import { removeSubscriptionSupervision } from "../tLN/removeSubscriptionSupervision.js";
@@ -32,7 +32,7 @@ export type UnsubscribeOptions = {
 export function unsubscribe(
   extRefs: Element[],
   options: UnsubscribeOptions = { ignoreSupervision: false }
-): (Update | Remove)[] {
+): (Update | Remove | Insert)[] {
   const updateActions: Update[] = [];
   const removeActions: Remove[] = [];
 

--- a/tLN/canRemoveSubscriptionSupervision.spec.ts
+++ b/tLN/canRemoveSubscriptionSupervision.spec.ts
@@ -1,0 +1,123 @@
+import { expect } from "chai";
+
+import {
+  gooseSubscriptionEd2,
+  svSubscriptionEd2,
+} from "./removeSubscription.testfiles.js";
+import { findElement } from "../foundation/helpers.test.js";
+
+import { canRemoveSubscriptionSupervision } from "./canRemoveSubscriptionSupervision.js";
+
+const docEd2Goose = findElement(gooseSubscriptionEd2) as XMLDocument;
+const docEd2Sv = findElement(svSubscriptionEd2) as XMLDocument;
+
+// const docEd2Sv = findElement(svSubscriptionEd2) as XMLDocument;
+
+describe("Function to check if supervision references can be removed (canRemoveSubscriptionSupervision)", () => {
+  describe("For GOOSE", () => {
+    describe("Only allows supervision removal if declared with valKind/valImport on DTTs/instances", () => {
+      it("does not return any action if neither declared", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber4"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.false;
+      });
+
+      it("allows removals if declared on DTTs with valKind=Conf/valImport=true", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber4"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][daName="stVal"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.true;
+      });
+
+      it("allows removals if declared on DTTs with valKind=RO/valImport=true", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber4"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"][srcCBName="GOOSE1"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.true;
+      });
+
+      it("allows removals if declared on first instantiated element with valKind=Conf/valImport=true", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber5"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][daName="stVal"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.true;
+      });
+
+      it("does not allow removals with only valKind=RO/Conf", () => {
+        const extRef1 = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber6"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][daName="stVal"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef1)).to.be.false;
+
+        const extRef2 = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber6"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"][srcCBName="GOOSE1"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef2)).to.be.false;
+      });
+
+      it("does not allow removals with only valImport=true", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber7"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.false;
+      });
+    });
+  });
+
+  describe("for SMV", () => {
+    describe("Only allows supervision removal if declared with valKind/valImport on DTTs/instances", () => {
+      it("does not return any action if neither valKind/valImport declared", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber4"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.false;
+      });
+
+      it("allows removals if declared on DTTs with valKind=Conf/valImport=true", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber4"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher2"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.true;
+      });
+
+      it("allows removals if declared on DTTs with valKind=RO/valImport=true", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber4"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.true;
+      });
+
+      it("allows removals if declared on first instantiated element with valKind=Conf/valImport=true", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber5"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.true;
+      });
+
+      it("does not allow removals with only valKind=RO/Conf", () => {
+        const extRef1 = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber6"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef1)).to.be.false;
+
+        const extRef2 = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber6"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher2"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef2)).to.be.false;
+      });
+
+      it("does not allow removals with only valImport=true", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber7"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+        expect(canRemoveSubscriptionSupervision(extRef)).to.be.false;
+      });
+    });
+  });
+
+  it("for an empty array it does not allow removals", () => {
+    const extRef = [];
+    expect(canRemoveSubscriptionSupervision(extRef)).to.be.false;
+  });
+});

--- a/tLN/canRemoveSubscriptionSupervision.ts
+++ b/tLN/canRemoveSubscriptionSupervision.ts
@@ -1,0 +1,109 @@
+import {
+  GroupedExtRefs,
+  groupPerControlBlock,
+  removableSupervisionElement,
+} from "./removeSubscriptionSupervision";
+
+/** @returns Whether `DA` with name `setSrcRef` can edited by SCL editor */
+function isSrcRefEditable(ctrlBlock: Element, subscriberIed: Element): boolean {
+  const supervisionElement = removableSupervisionElement(
+    ctrlBlock,
+    subscriberIed
+  );
+
+  const ln = supervisionElement?.closest("LN") ?? null;
+  if (!ln) return false;
+
+  const lnClass = ln.getAttribute("lnClass");
+  const cbRefType = lnClass === "LGOS" ? "GoCBRef" : "SvCBRef";
+
+  if (
+    ln.querySelector(
+      `:scope > DOI[name="${cbRefType}"] > DAI[name="setSrcRef"][valImport="true"][valKind="RO"],` +
+        ` :scope > DOI[name="${cbRefType}"] > DAI[name="setSrcRef"][valImport="true"][valKind="Conf"]`
+    )
+  )
+    return true;
+
+  const rootNode = ln.ownerDocument;
+
+  const lnType = ln.getAttribute("lnType");
+
+  const goOrSvCBRef = rootNode.querySelector(
+    `DataTypeTemplates > 
+          LNodeType[id="${lnType}"][lnClass="${lnClass}"] > DO[name="${cbRefType}"]`
+  );
+
+  const cbRefId = goOrSvCBRef?.getAttribute("type");
+  const setSrcRef = rootNode.querySelector(
+    `DataTypeTemplates > DOType[id="${cbRefId}"] > DA[name="setSrcRef"]`
+  );
+
+  return (
+    (setSrcRef?.getAttribute("valKind") === "Conf" ||
+      setSrcRef?.getAttribute("valKind") === "RO") &&
+    setSrcRef.getAttribute("valImport") === "true"
+  );
+}
+
+/** @returns Whether other subscribed ExtRef of the same control block exist */
+function isControlBlockSubscribed(extRefs: Element[]): boolean {
+  const [
+    srcCBName,
+    srcLDInst,
+    srcLNClass,
+    iedName,
+    srcPrefix,
+    srcLNInst,
+    serviceType,
+  ] = [
+    "srcCBName",
+    "srcLDInst",
+    "srcLNClass",
+    "iedName",
+    "srcPrefix",
+    "srcLNInst",
+    "serviceType",
+  ].map((attr) => extRefs[0].getAttribute(attr));
+
+  const parentIed = extRefs[0].closest("IED");
+  return Array.from(parentIed!.getElementsByTagName("ExtRef")).some(
+    (otherExtRef) =>
+      !extRefs.includes(otherExtRef) &&
+      (otherExtRef.getAttribute("srcPrefix") ?? "") === (srcPrefix ?? "") &&
+      (otherExtRef.getAttribute("srcLNInst") ?? "") === (srcLNInst ?? "") &&
+      otherExtRef.getAttribute("srcCBName") === srcCBName &&
+      otherExtRef.getAttribute("srcLDInst") === srcLDInst &&
+      otherExtRef.getAttribute("srcLNClass") === srcLNClass &&
+      otherExtRef.getAttribute("iedName") === iedName &&
+      otherExtRef.getAttribute("serviceType") === serviceType
+  );
+}
+
+export function cannotRemoveSupervision(extRefGroup: GroupedExtRefs): boolean {
+  return (
+    isControlBlockSubscribed(extRefGroup.extRefs) ||
+    !isSrcRefEditable(extRefGroup.ctrlBlock, extRefGroup.subscriberIed)
+  );
+}
+
+/**
+ * Checks if a group of ExtRefs can have their supervision references removed
+ * @param extRefOrExtRefs - An SCL ExtRef element or array of them.
+ * @returns true if all supervision references can be removed.
+ */
+export function canRemoveSubscriptionSupervision(
+  extRefOrExtRefs: Element | Element[]
+): boolean {
+  if (!extRefOrExtRefs) return false;
+
+  const extRefs = Array.isArray(extRefOrExtRefs)
+    ? extRefOrExtRefs
+    : [extRefOrExtRefs];
+
+  const groupedExtRefs = groupPerControlBlock(extRefs);
+
+  return Object.values(groupedExtRefs).some(
+    (extRefGroup) => !cannotRemoveSupervision(extRefGroup)
+  );
+}

--- a/tLN/removeSubscription.testfiles.ts
+++ b/tLN/removeSubscription.testfiles.ts
@@ -1,0 +1,1917 @@
+export const gooseSubscriptionEd2 = `
+
+<SCL xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B" release="4">
+	<Header id="GOOSELaterBinding"/>
+	<Communication>
+		<SubNetwork name="StationBus" desc="" type="8-MMS">
+			<BitRate unit="b/s" multiplier="M">100</BitRate>
+			<ConnectedAP iedName="GOOSE_Subscriber1" apName="AP1"/>
+			<ConnectedAP iedName="GOOSE_Subscriber2" apName="AP1"/>
+			<ConnectedAP iedName="GOOSE_Subscriber3" apName="AP1"/>
+			<ConnectedAP iedName="GOOSE_Subscriber4" apName="AP1"/>
+			<ConnectedAP iedName="GOOSE_Publisher" apName="AP1">
+				<GSE ldInst="QB2_Disconnector" cbName="GOOSE2">
+					<Address>
+						<P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-01</P>
+						<P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0002</P>
+					</Address>
+					<MinTime unit="s" multiplier="m">10</MinTime>
+					<MaxTime unit="s" multiplier="m">1000</MaxTime>
+				</GSE>
+				<GSE ldInst="QB2_Disconnector" cbName="GOOSE1">
+					<Address>
+						<P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-00</P>
+						<P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0001</P>
+					</Address>
+					<MinTime unit="s" multiplier="m">10</MinTime>
+					<MaxTime unit="s" multiplier="m">1000</MaxTime>
+				</GSE>
+			</ConnectedAP>
+			<ConnectedAP iedName="GOOSE_Publisher2" apName="AP1">
+				<GSE ldInst="QB2_Disconnector" cbName="GOOSE2">
+					<Address>
+						<P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-03</P>
+						<P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0003</P>
+					</Address>
+					<MinTime unit="s" multiplier="m">10</MinTime>
+					<MaxTime unit="s" multiplier="m">1000</MaxTime>
+				</GSE>
+				<GSE ldInst="QB2_Disconnector" cbName="GOOSE1">
+					<Address>
+						<P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="MAC-Address" xsi:type="tP_MAC-Address">01-0C-CD-01-00-04</P>
+						<P xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="APPID" xsi:type="tP_APPID">0004</P>
+					</Address>
+					<MinTime unit="s" multiplier="m">10</MinTime>
+					<MaxTime unit="s" multiplier="m">1000</MaxTime>
+				</GSE>
+			</ConnectedAP>
+		</SubNetwork>
+	</Communication>
+	<IED name="GOOSE_Subscriber" desc="GOOSE subscriber" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Earth_Switch">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+						</Inputs>
+					</LN0>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO">
+						<Inputs>
+							<ExtRef desc="missingIntAddr"/>
+							<ExtRef desc="subscribedExtRef" intAddr="someIntAddr" iedName="GOOSE_Publisher"/>
+							<ExtRef intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input"/>
+							<ExtRef intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input2"/>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input2"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Subscriber1" desc="GOOSE subscriber" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxGo="4" maxSv="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Earth_Switch">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+							<ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+							<ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+							<ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+							<ExtRef intAddr="restrictExtRef" desc="Restricted To Pos" pLN="CSWI" pDO="Pos" pDA="stVal"/>
+						</Inputs>
+					</LN0>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO">
+						<Inputs>
+							<ExtRef intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input"/>
+							<ExtRef intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/stVal" desc="Interlocking.Input2"/>
+							<ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input2"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To Pos" pLN="CSWI" pDO="Pos" pDA="stVal"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+				<LDevice inst="Supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS">
+						<Private type="OpenSCD.create"/>
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS">
+						<Private type="OpenSCD.create"/>
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE1</Val>
+							</DAI>
+						</DOI>
+					</LN>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Subscriber2" desc="GOOSE subscriber" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxGo="4" maxSv="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Earth_Switch">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher2" intAddr="NoSrcAttrs" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q"/>
+							<ExtRef iedName="GOOSE_Publisher2" intAddr="IncorrectGSEControl" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE99"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+					<LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS1" desc="Can be removed">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+				</LDevice>
+				<LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS"/>
+					<LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS"/>
+					<LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS"/>
+					<LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Subscriber3" desc="GOOSE subscriber" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxGo="4" maxSv="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Earth_Switch">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO">
+						<Inputs>
+                            <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+                            <ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="q" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+                            <ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB1_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE1" intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input1"/>
+                            <ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2" intAddr="Pos;CSWI1/Pos/q" desc="Interlocking.Input2"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+				<LDevice inst="Supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS"/>
+                    <LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE1</Val>
+							</DAI>
+						</DOI>
+					</LN>
+                    <LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Subscriber4" desc="GOOSE subscriber" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxGo="4" maxSv="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Earth_Switch">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+							<ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE1"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS2" desc="Cannot be removed">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS1" desc="Can be removed from DTT with Conf">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS" desc="Can be removed from DTT with RO">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef">
+								<Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE1</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Subscriber5" desc="GOOSE subscriber" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxGo="4" maxSv="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Earth_Switch">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+							<ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+				<LDevice inst="Supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS2" desc="Can be removed, instantiated on the DAI valImport=true and valKind=RO">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef" valImport="true" valKind="RO">
+								<Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS2" desc="Can be removed, instantiated on the DAI valImport=true and valKind=Conf">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef" valImport="true" valKind="Conf">
+								<Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS2"/>
+					<LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Subscriber6" desc="GOOSE subscriber" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxGo="4" maxSv="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Earth_Switch">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE1"/>
+							<ExtRef iedName="GOOSE_Publisher2" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE2"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+				<LDevice inst="Supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS2" desc="Cannot be removed, only instantiated on valKind">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef" valKind="RO">
+								<Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE1</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS2" desc="Cannot be removed, only instantiated on valKind">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef" valKind="Conf">
+								<Val>GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE2</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS2"/>
+					<LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Subscriber7" desc="GOOSE subscriber" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxGo="4" maxSv="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Earth_Switch">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI">
+						<Inputs>
+							<ExtRef iedName="GOOSE_Publisher" serviceType="GOOSE" ldInst="QB2_Disconnector" lnClass="CSWI" lnInst="1" prefix="" doName="Pos" daName="stVal" srcLDInst="QB2_Disconnector" srcPrefix="" srcLNClass="LLN0" srcCBName="GOOSE1"/>
+						</Inputs>
+					</LN>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+				<LDevice inst="Supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LGOS" inst="1" lnType="Dummy.LGOS2" desc="Cannot be removed only instantiated on valImport">
+						<DOI name="GoCBRef">
+							<DAI name="setSrcRef" valImport="true">
+								<Val>GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE1</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LGOS" inst="2" lnType="Dummy.LGOS2"/>
+					<LN lnClass="LGOS" inst="3" lnType="Dummy.LGOS2"/>
+					<LN lnClass="LGOS" inst="4" lnType="Dummy.LGOS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Publisher" desc="GOOSE publisher" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="QB2_Disconnector">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<DataSet name="GOOSE2sDataSet">
+							<FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+							<FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+						</DataSet>
+						<DataSet name="GOOSE1sDataSet">
+							<FCDA ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+							<FCDA ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+						</DataSet>
+						<GSEControl name="GOOSE2" type="GOOSE" appID="GOOSE2" confRev="1" datSet="GOOSE2sDataSet"/>
+						<GSEControl name="GOOSE1" type="GOOSE" appID="GOOSE1" confRev="1" datSet="GOOSE1sDataSet"/>
+					</LN0>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+				<LDevice inst="QB1_Disconnector">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="GOOSE_Publisher2" desc="GOOSE publisher" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="QB2_Disconnector">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<DataSet name="GOOSE2sDataSet">
+							<FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+							<FCDA ldInst="QB2_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+						</DataSet>
+						<DataSet name="GOOSE1sDataSet">
+							<FCDA ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+							<FCDA ldInst="QB1_Disconnector" prefix="" lnClass="CSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+						</DataSet>
+						<GSEControl name="GOOSE2" type="GOOSE" appID="GOOSE2" confRev="1" datSet="GOOSE2sDataSet"/>
+						<GSEControl name="GOOSE1" type="GOOSE" appID="GOOSE1" confRev="1" datSet="GOOSE1sDataSet"/>
+					</LN0>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+				<LDevice inst="QB1_Disconnector">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="CILO" inst="1" lnType="Dummy.CILO"/>
+					<LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI"/>
+					<LN prefix="" lnClass="XSWI" inst="1" lnType="Dummy.XSWI"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<DataTypeTemplates>
+		<LNodeType lnClass="LGOS" id="Dummy.LGOS">
+			<DO name="GoCBRef" type="Dummy.ORG" desc="RO/true"/>
+			<DO name="St" type="OpenSCD_SPS_simple"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+		</LNodeType>
+		<LNodeType lnClass="LGOS" id="Dummy.LGOS1">
+			<DO name="GoCBRef" type="Dummy.ORG1" desc="conf/true"/>
+			<DO name="LikeGoCBRef" type="Dummy.ORG1"/>
+			<DO name="St" type="OpenSCD_SPS_simple"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+		</LNodeType>
+		<LNodeType lnClass="LGOS" id="Dummy.LGOS2" desc="null/null">
+			<DO name="GoCBRef" type="Dummy.ORG2"/>
+			<DO name="St" type="OpenSCD_SPS_simple"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+		</LNodeType>
+		<LNodeType lnClass="XSWI" id="Dummy.XSWI" desc="Switch: one phase represenation">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+			<DO name="OpCnt" type="OpenSCD_INS_simple"/>
+			<DO name="Pos" type="OpenSCD_DPC_statusonly"/>
+			<DO name="BlkOpn" type="OpenSCD_SPC_statusonly"/>
+			<DO name="BlkCls" type="OpenSCD_SPC_statusonly"/>
+			<DO name="SwTyp" type="OpenSCD_ENS_SwTyp"/>
+		</LNodeType>
+		<LNodeType lnClass="CSWI" id="Dummy.CSWI" desc="Switch control: no process bus(PB)">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+			<DO name="Pos" type="OpenSCD_DPC"/>
+		</LNodeType>
+		<LNodeType lnClass="CILO" id="Dummy.CILO" desc="Interlocking">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="EnaOpn" type="OpenSCD_SPS_simple"/>
+			<DO name="EnaCls" type="OpenSCD_SPS_simple"/>
+		</LNodeType>
+		<LNodeType lnClass="LLN0" id="Dummy.LLN0" desc="Logical device LN: parent">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+		</LNodeType>
+		<DOType cdc="ORG" id="Dummy.ORG">
+			<DA name="setSrcRef" bType="ObjRef" dchg="true" valKind="RO" valImport="true" fc="SP"/>
+		</DOType>
+		<DOType cdc="ORG" id="Dummy.ORG1">
+			<DA name="setSrcRef" bType="ObjRef" dchg="true" valKind="Conf" valImport="true" fc="SP"/>
+		</DOType>
+		<DOType cdc="ORG" id="Dummy.ORG2">
+			<DA name="setSrcRef" bType="ObjRef" dchg="true" fc="SP"/>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_ENS_SwTyp">
+			<DA fc="ST" dchg="true" name="stVal" bType="Enum" type="SwitchFunctionKind"/>
+			<DA fc="ST" qchg="true" name="q" bType="Quality"/>
+			<DA fc="ST" name="t" bType="Timestamp"/>
+		</DOType>
+		<DOType cdc="SPC" id="OpenSCD_SPC_statusonly">
+			<DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" dchg="true" type="OpenSCD_StatusOnly" fc="CF">
+				<Val>status-only</Val>
+			</DA>
+		</DOType>
+		<DOType cdc="DPC" id="OpenSCD_DPC_statusonly">
+			<DA name="stVal" bType="Dbpos" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" fc="CF" type="OpenSCD_StatusOnly">
+				<Val>status-only</Val>
+			</DA>
+		</DOType>
+		<DOType cdc="INS" id="OpenSCD_INS_simple">
+			<DA name="stVal" bType="INT32" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="DPC" id="OpenSCD_DPC">
+			<DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+			<DA name="stVal" bType="Dbpos" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+				<Val>sbo-with-enhanced-security</Val>
+			</DA>
+			<DA name="sboTimeout" bType="INT32U" fc="CF">
+				<Val>30000</Val>
+			</DA>
+			<DA name="operTimeout" bType="INT32U" fc="CF">
+				<Val>600</Val>
+			</DA>
+			<DA name="pulseConfig" bType="Struct" fc="CO" type="OpenSCD_PulseConfig"/>
+			<DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+			<DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+			<DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_Dbpos"/>
+		</DOType>
+		<DOType cdc="LPL" id="OpenSCD_LPL_noLD">
+			<DA name="vendor" bType="VisString255" fc="DC"/>
+			<DA name="swRev" bType="VisString255" fc="DC"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+			<DA name="configRev" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="SPS" id="OpenSCD_SPS_simple">
+			<DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="LPL" id="OpenSCD_LPL_LD">
+			<DA name="vendor" bType="VisString255" fc="DC"/>
+			<DA name="swRev" bType="VisString255" fc="DC"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+			<DA name="configRev" bType="VisString255" fc="DC"/>
+			<DA name="ldNs" bType="VisString255" fc="EX">
+				<Val>IEC 61850-7-4:2007B4</Val>
+			</DA>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_ENS_Health">
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="HealthKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_ENS_Beh">
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ENC" id="OpenSCD_ENC_Mod">
+			<DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+				<Val>sbo-with-enhanced-security</Val>
+			</DA>
+			<DA name="sboTimeout" bType="INT32U" fc="CF">
+				<Val>30000</Val>
+			</DA>
+			<DA name="operTimeout" bType="INT32U" fc="CF">
+				<Val>600</Val>
+			</DA>
+			<DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+			<DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+			<DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_BehaviourModeKind"/>
+		</DOType>
+		<DAType id="OpenSCD_Cancel_Dbpos">
+			<BDA name="ctlVal" bType="Dbpos"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_OperSBOw_Dbpos">
+			<BDA name="ctlVal" bType="Dbpos"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<BDA name="Check" bType="Check"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_PulseConfig">
+			<BDA name="cmdQual" bType="Enum" type="OutputSignalKind"/>
+			<BDA name="onDur" bType="INT32U"/>
+			<BDA name="offDur" bType="INT32U"/>
+			<BDA name="numPls" bType="INT32U"/>
+		</DAType>
+		<DAType id="OpenSCD_Cancel_BehaviourModeKind">
+			<BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_OperSBOw_BehaviourModeKind">
+			<BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<BDA name="Check" bType="Check"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_Originator">
+			<BDA name="orCat" bType="Enum" type="OriginatorCategoryKind"/>
+			<BDA name="orIdent" bType="Octet64"/>
+		</DAType>
+		<EnumType id="SwitchFunctionKind">
+			<EnumVal ord="1">Load Break</EnumVal>
+			<EnumVal ord="2">Disconnector</EnumVal>
+			<EnumVal ord="3">Earthing Switch</EnumVal>
+			<EnumVal ord="4">High Speed Earthing Switch</EnumVal>
+		</EnumType>
+		<EnumType id="OpenSCD_StatusOnly">
+			<EnumVal ord="0">status-only</EnumVal>
+		</EnumType>
+		<EnumType id="OutputSignalKind">
+			<EnumVal ord="0">pulse</EnumVal>
+			<EnumVal ord="1">persistent</EnumVal>
+			<EnumVal ord="2">persistent-feedback</EnumVal>
+		</EnumType>
+		<EnumType id="HealthKind">
+			<EnumVal ord="1">Ok</EnumVal>
+			<EnumVal ord="2">Warning</EnumVal>
+			<EnumVal ord="3">Alarm</EnumVal>
+		</EnumType>
+		<EnumType id="CtlModelKind">
+			<EnumVal ord="0">status-only</EnumVal>
+			<EnumVal ord="1">direct-with-normal-security</EnumVal>
+			<EnumVal ord="2">sbo-with-normal-security</EnumVal>
+			<EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+			<EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
+		</EnumType>
+		<EnumType id="BehaviourModeKind">
+			<EnumVal ord="1">on</EnumVal>
+			<EnumVal ord="2">blocked</EnumVal>
+			<EnumVal ord="3">test</EnumVal>
+			<EnumVal ord="4">test/blocked</EnumVal>
+			<EnumVal ord="5">off</EnumVal>
+		</EnumType>
+		<EnumType id="OriginatorCategoryKind">
+			<EnumVal ord="0">not-supported</EnumVal>
+			<EnumVal ord="1">bay-control</EnumVal>
+			<EnumVal ord="2">station-control</EnumVal>
+			<EnumVal ord="3">remote-control</EnumVal>
+			<EnumVal ord="4">automatic-bay</EnumVal>
+			<EnumVal ord="5">automatic-station</EnumVal>
+			<EnumVal ord="6">automatic-remote</EnumVal>
+			<EnumVal ord="7">maintenance</EnumVal>
+			<EnumVal ord="8">process</EnumVal>
+		</EnumType>
+	</DataTypeTemplates>
+</SCL>
+
+`;
+
+export const svSubscriptionEd2 = `
+
+<SCL xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B" release="4">
+	<Header id="project"/>
+	<Substation name="AA1" desc="">
+		<VoltageLevel name="E1" desc="" nomFreq="50" numPhases="3">
+			<Voltage unit="V" multiplier="k">110</Voltage>
+			<Bay name="Q01" desc="">
+				<ConductingEquipment name="B5" type="VTR" desc="">
+					<EqFunction name="CurrentTransformer">
+						<EqSubFunction name="L3">
+							<LNode iedName="None" lnClass="TCTR" lnInst="1" lnType="Dummy.TCTR"/>
+						</EqSubFunction>
+						<EqSubFunction name="L2">
+							<LNode iedName="None" lnClass="TCTR" lnInst="1" lnType="Dummy.TCTR"/>
+						</EqSubFunction>
+						<EqSubFunction name="RES">
+							<LNode iedName="None" lnClass="TCTR" lnInst="1" lnType="Dummy.TCTR"/>
+						</EqSubFunction>
+						<EqSubFunction name="L1">
+							<LNode iedName="None" lnClass="TCTR" lnInst="1" lnType="Dummy.TCTR"/>
+						</EqSubFunction>
+					</EqFunction>
+				</ConductingEquipment>
+				<ConductingEquipment name="B1" type="CTR" desc="">
+					<EqFunction name="VoltageTransformer">
+						<EqSubFunction name="L3">
+							<LNode iedName="None" lnClass="TVTR" lnInst="1" lnType="Dummy.TVTR"/>
+						</EqSubFunction>
+						<EqSubFunction name="L2">
+							<LNode iedName="None" lnClass="TVTR" lnInst="1" lnType="Dummy.TVTR"/>
+						</EqSubFunction>
+						<EqSubFunction name="RES">
+							<LNode iedName="None" lnClass="TVTR" lnInst="1" lnType="Dummy.TVTR"/>
+						</EqSubFunction>
+						<EqSubFunction name="L1">
+							<LNode iedName="None" lnClass="TVTR" lnInst="1" lnType="Dummy.TVTR"/>
+						</EqSubFunction>
+					</EqFunction>
+				</ConductingEquipment>
+				<Function name="Overvoltage">
+					<LNode iedName="None" lnClass="PTRC" lnInst="1" lnType="Summy.PTRC"/>
+				</Function>
+				<Function name="Overcurrent">
+					<LNode iedName="None" lnClass="PTRC" lnInst="1" lnType="Summy.PTRC"/>
+				</Function>
+			</Bay>
+		</VoltageLevel>
+	</Substation>
+	<Communication>
+		<SubNetwork name="ProcessBus" desc="" type="8-MMS">
+			<BitRate unit="b/s" multiplier="M">100</BitRate>
+			<ConnectedAP iedName="SMV_Subscriber" apName="AP1"/>
+			<ConnectedAP iedName="SMV_Publisher" apName="AP1">
+				<SMV ldInst="CurrentTransformer" cbName="fullSmv">
+					<Address>
+						<P type="MAC-Address" xsi:type="tP_MAC-Address"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">01-0C-CD-04-00-02</P>
+						<P type="APPID" xsi:type="tP_APPID"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">0003</P>
+					</Address>
+				</SMV>
+				<SMV ldInst="CurrentTransformer" cbName="voltageOnly">
+					<Address>
+						<P type="MAC-Address" xsi:type="tP_MAC-Address"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">01-0C-CD-04-00-01</P>
+						<P type="APPID" xsi:type="tP_APPID"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">0002</P>
+					</Address>
+				</SMV>
+				<SMV ldInst="CurrentTransformer" cbName="currentOnly">
+					<Address>
+						<P type="MAC-Address" xsi:type="tP_MAC-Address"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">01-0C-CD-04-00-00</P>
+						<P type="APPID" xsi:type="tP_APPID"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">0001</P>
+					</Address>
+				</SMV>
+			</ConnectedAP>
+		</SubNetwork>
+	</Communication>
+	<IED xmlns="http://www.iec.ch/61850/2003/SCL" name="SMV_Subscriber" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxSv="4" maxGo="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Overvoltage">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+                            <ExtRef intAddr="AmpSv;TCTR1/AmpSv/instMag.i" desc="MeasPoint.CT1" iedName="SMV_Publisher2" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/instMag.i" desc="MeasPoint.CT2"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/instMag.i" desc="MeasPoint.CT3" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="sillyLikeA" serviceType="GOOSE"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Overcurrent">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/instMag.i" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/instMag.i" desc="MeasPoint.VT2"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/instMag.i" desc="MeasPoint.VT3"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To AmpSV" pLN="TCTR" pDO="AmpSV" pDA="instMag.i"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LSVS" inst="1" lnType="Dummy.LSVS">
+						<Private type="OpenSCD.create" />
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef">
+								<Val>SMV_Publisher2CurrentTransformer/LLN0.voltageOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+                    <LN lnClass="LSVS" inst="2" lnType="Dummy.LSVS">
+						<Private type="OpenSCD.create" />
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.currentOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED xmlns="http://www.iec.ch/61850/2003/SCL" name="SMV_Subscriber2" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxSv="4" maxGo="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Overvoltage">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/instMag.i" desc="MeasPoint.CT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV"/>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/instMag.i" desc="MeasPoint.CT2"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/instMag.i" desc="MeasPoint.CT3"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/q" desc="MeasPoint.CT1"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Overcurrent">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/instMag.i" desc="MeasPoint.VT1" iedName="SMV_Publisher2" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnlyNotThere"/>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/instMag.i" desc="MeasPoint.VT2"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/instMag.i" desc="MeasPoint.VT3"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To AmpSV" pLN="TCTR" pDO="AmpSV" pDA="instMag.i"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LSVS" inst="1" lnType="Dummy.LSVS1">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.currentOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LSVS" inst="2" lnType="Dummy.LSVS1">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef">
+								<Val>SMV_Publisher2CurrentTransformer/LLN0.currentOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LSVS" inst="3" lnType="Dummy.LSVS1"/>
+					<LN lnClass="LSVS" inst="4" lnType="Dummy.LSVS1"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED xmlns="http://www.iec.ch/61850/2003/SCL" name="SMV_Subscriber3" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Overcurrent">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/instMag.i" desc="MeasPoint.CT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/q" desc="MeasPoint.CT1"  iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/instMag.i" desc="MeasPoint.CT2" iedName="SMV_Publisher2" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/instMag.i" desc="MeasPoint.CT3" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="fullSmv"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/q" desc="MeasPoint.CT1"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Overvoltage">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/instMag.i" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/instMag.i" desc="MeasPoint.VT2"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/instMag.i" desc="MeasPoint.VT3"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To AmpSV" pLN="TCTR" pDO="AmpSV" pDA="instMag.i"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+                <LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LSVS" inst="1" lnType="Dummy.LSVS1">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef">
+								<Val>SMV_Publisher2CurrentTransformer/LLN0.currentOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LSVS" inst="2" lnType="Dummy.LSVS1">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.fullSmv</Val>
+							</DAI>
+						</DOI>
+					</LN>
+                    <LN lnClass="LSVS" inst="3" lnType="Dummy.LSVS1">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.currentOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="LSVS" inst="4" lnType="Dummy.LSVS1"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED xmlns="http://www.iec.ch/61850/2003/SCL" name="SMV_Subscriber4" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxSv="4" maxGo="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Overcurrent">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/instMag.i" desc="MeasPoint.CT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/instMag.i" desc="MeasPoint.CT2"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/instMag.i" desc="MeasPoint.CT3" iedName="SMV_Publisher2" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/q" desc="MeasPoint.CT1"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Overvoltage">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/instMag.i" desc="MeasPoint.VT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="voltageOnly"/>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/instMag.i" desc="MeasPoint.VT2"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/instMag.i" desc="MeasPoint.VT3"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To AmpSV" pLN="TCTR" pDO="AmpSV" pDA="instMag.i"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LSVS" inst="1" lnType="Dummy.LSVS2">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.currentOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+                    <LN lnClass="LSVS" inst="2" lnType="Dummy.LSVS1">
+                        <DOI name="SvCBRef">
+                            <DAI name="setSrcRef">
+                                <Val>SMV_Publisher2CurrentTransformer/LLN0.currentOnly</Val>
+                            </DAI>
+                        </DOI>
+                    </LN>
+					<LN lnClass="LSVS" inst="3" lnType="Dummy.LSVS1">
+                        <DOI name="SvCBRef">
+                            <DAI name="setSrcRef">
+                                <Val>SMV_PublisherCurrentTransformer/LLN0.voltageOnly</Val>
+                            </DAI>
+                        </DOI>
+                    </LN>
+					<LN lnClass="LSVS" inst="4" lnType="Dummy.LSVS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED xmlns="http://www.iec.ch/61850/2003/SCL" name="SMV_Subscriber5" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxSv="4" maxGo="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Overcurrent">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/instMag.i" desc="MeasPoint.CT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/instMag.i" desc="MeasPoint.CT2"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/instMag.i" desc="MeasPoint.CT3" iedName="SMV_Publisher2" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/q" desc="MeasPoint.CT1"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Overvoltage">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/instMag.i" desc="MeasPoint.VT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="voltageOnly"/>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/instMag.i" desc="MeasPoint.VT2"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/instMag.i" desc="MeasPoint.VT3"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To AmpSV" pLN="TCTR" pDO="AmpSV" pDA="instMag.i"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LSVS" inst="1" lnType="Dummy.LSVS2">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef" valKind="Conf" valImport="true">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.voltageOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+                    <LN lnClass="LSVS" inst="2" lnType="Dummy.LSVS2"/>
+                    <LN lnClass="LSVS" inst="3" lnType="Dummy.LSVS2"/>
+					<LN lnClass="LSVS" inst="4" lnType="Dummy.LSVS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED xmlns="http://www.iec.ch/61850/2003/SCL" name="SMV_Subscriber6" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxSv="4" maxGo="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Overcurrent">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/instMag.i" desc="MeasPoint.CT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/instMag.i" desc="MeasPoint.CT2"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/instMag.i" desc="MeasPoint.CT3" iedName="SMV_Publisher2" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/q" desc="MeasPoint.CT1"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Overvoltage">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/instMag.i" desc="MeasPoint.VT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="voltageOnly"/>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/instMag.i" desc="MeasPoint.VT2"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/instMag.i" desc="MeasPoint.VT3"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To AmpSV" pLN="TCTR" pDO="AmpSV" pDA="instMag.i"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LSVS" inst="1" lnType="Dummy.LSVS2">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef" valKind="Conf">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.voltageOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+                    <LN lnClass="LSVS" inst="2" lnType="Dummy.LSVS2">
+                        <DOI name="SvCBRef">
+                            <DAI name="setSrcRef" valKind="RO">
+                                <Val>SMV_Publisher2CurrentTransformer/LLN0.currentOnly</Val>
+                            </DAI>
+                        </DOI>
+                    </LN>
+                    <LN lnClass="LSVS" inst="3" lnType="Dummy.LSVS2"/>
+					<LN lnClass="LSVS" inst="4" lnType="Dummy.LSVS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED xmlns="http://www.iec.ch/61850/2003/SCL" name="SMV_Subscriber6" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxSv="4" maxGo="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Overcurrent">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/instMag.i" desc="MeasPoint.CT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/instMag.i" desc="MeasPoint.CT2"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/instMag.i" desc="MeasPoint.CT3" iedName="SMV_Publisher2" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/q" desc="MeasPoint.CT1"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Overvoltage">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/instMag.i" desc="MeasPoint.VT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="voltageOnly"/>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/instMag.i" desc="MeasPoint.VT2"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/instMag.i" desc="MeasPoint.VT3"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To AmpSV" pLN="TCTR" pDO="AmpSV" pDA="instMag.i"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LSVS" inst="1" lnType="Dummy.LSVS2">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef" valKind="Conf">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.voltageOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+                    <LN lnClass="LSVS" inst="2" lnType="Dummy.LSVS2"/>
+                    <LN lnClass="LSVS" inst="3" lnType="Dummy.LSVS2"/>
+					<LN lnClass="LSVS" inst="4" lnType="Dummy.LSVS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+    <IED xmlns="http://www.iec.ch/61850/2003/SCL" name="SMV_Subscriber7" manufacturer="Dummy">
+		<Services>
+			<SupSubscription maxSv="4" maxGo="0"/>
+		</Services>
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="Overcurrent">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/instMag.i" desc="MeasPoint.CT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR1/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/instMag.i" desc="MeasPoint.CT2"/>
+							<ExtRef intAddr="AmpSv;TCTR2/AmpSv/q" desc="MeasPoint.CT1"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/instMag.i" desc="MeasPoint.CT3" iedName="SMV_Publisher2" ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="currentOnly"/>
+							<ExtRef intAddr="AmpSv;TCTR3/AmpSv/q" desc="MeasPoint.CT1"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="Overvoltage">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="" lnClass="PTRC" inst="1" lnType="Summy.PTRC">
+						<Inputs>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/instMag.i" desc="MeasPoint.VT1" iedName="SMV_Publisher" ldInst="CurrentTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" serviceType="SMV" srcLDInst="CurrentTransformer" srcLNClass="LLN0" srcCBName="voltageOnly"/>
+							<ExtRef intAddr="VolSv;TVTR1/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/instMag.i" desc="MeasPoint.VT2"/>
+							<ExtRef intAddr="VolSv;TVTR2/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/instMag.i" desc="MeasPoint.VT3"/>
+							<ExtRef intAddr="VolSv;TVTR3/VolSv/q" desc="MeasPoint.VT1"/>
+							<ExtRef intAddr="someRestrictedExtRef" desc="Restricted To AmpSV" pLN="TCTR" pDO="AmpSV" pDA="instMag.i"/>
+						</Inputs>
+					</LN>
+				</LDevice>
+				<LDevice inst="SV_supervision">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN lnClass="LSVS" inst="1" lnType="Dummy.LSVS2">
+						<DOI name="SvCBRef">
+							<DAI name="setSrcRef" valKind="Conf">
+								<Val>SMV_PublisherCurrentTransformer/LLN0.voltageOnly</Val>
+							</DAI>
+						</DOI>
+					</LN>
+                    <LN lnClass="LSVS" inst="2" lnType="Dummy.LSVS2"/>
+                    <LN lnClass="LSVS" inst="3" lnType="Dummy.LSVS2"/>
+					<LN lnClass="LSVS" inst="4" lnType="Dummy.LSVS2"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="SMV_Publisher" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="CurrentTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<DataSet name="fullSmvsDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="voltageOnlysDataSet">
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="currentOnlysDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+						</DataSet>
+						<SampledValueControl name="fullSmv" multicast="true" smvID="smv3" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="fullSmvsDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="voltageOnly" multicast="true" smvID="smv2" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="voltageOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="currentOnly" multicast="true" smvID="firstSMV" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="currentOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+					</LN0>
+					<LN prefix="L3" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L2" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="RES" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L1" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+				</LDevice>
+				<LDevice inst="VoltageTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="L3" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L2" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="RES" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L1" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="SMV_Publisher2" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="CurrentTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<DataSet name="fullSmvsDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="voltageOnlysDataSet">
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="currentOnlysDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+						</DataSet>
+						<SampledValueControl name="fullSmv" multicast="true" smvID="smv3" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="fullSmvsDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="voltageOnly" multicast="true" smvID="smv2" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="voltageOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="currentOnly" multicast="true" smvID="firstSMV" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="currentOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+					</LN0>
+					<LN prefix="L3" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L2" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="RES" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L1" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+				</LDevice>
+				<LDevice inst="VoltageTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="L3" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L2" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="RES" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L1" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="SMV_Publisher3" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="CurrentTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<DataSet name="fullSmvsDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="voltageOnlysDataSet">
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="currentOnlysDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+						</DataSet>
+						<SampledValueControl name="fullSmv" multicast="true" smvID="smv3" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="fullSmvsDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="voltageOnly" multicast="true" smvID="smv2" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="voltageOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="currentOnly" multicast="true" smvID="firstSMV" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="currentOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+					</LN0>
+					<LN prefix="L3" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L2" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="RES" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L1" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+				</LDevice>
+				<LDevice inst="VoltageTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="L3" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L2" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="RES" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L1" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="SMV_Publisher4" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="CurrentTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<DataSet name="fullSmvsDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="voltageOnlysDataSet">
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="currentOnlysDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+						</DataSet>
+						<SampledValueControl name="fullSmv" multicast="true" smvID="smv3" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="fullSmvsDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="voltageOnly" multicast="true" smvID="smv2" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="voltageOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="currentOnly" multicast="true" smvID="firstSMV" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="currentOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+					</LN0>
+					<LN prefix="L3" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L2" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="RES" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L1" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+				</LDevice>
+				<LDevice inst="VoltageTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="L3" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L2" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="RES" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L1" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<IED name="SMV_Publisher5" manufacturer="Dummy">
+		<AccessPoint name="AP1">
+			<Server>
+				<Authentication/>
+				<LDevice inst="CurrentTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+						<DataSet name="fullSmvsDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="voltageOnlysDataSet">
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L1" lnClass="TVTR" lnInst="1" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L2" lnClass="TVTR" lnInst="2" doName="VolSv" daName="q" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="VoltageTransformer" prefix="L3" lnClass="TVTR" lnInst="3" doName="VolSv" daName="q" fc="MX"/>
+						</DataSet>
+						<DataSet name="currentOnlysDataSet">
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L1" lnClass="TCTR" lnInst="1" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L2" lnClass="TCTR" lnInst="2" doName="AmpSv" daName="q" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="instMag.i" fc="MX"/>
+							<FCDA ldInst="CurrentTransformer" prefix="L3" lnClass="TCTR" lnInst="3" doName="AmpSv" daName="q" fc="MX"/>
+						</DataSet>
+						<SampledValueControl name="fullSmv" multicast="true" smvID="smv3" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="fullSmvsDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="voltageOnly" multicast="true" smvID="smv2" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="voltageOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+						<SampledValueControl name="currentOnly" multicast="true" smvID="firstSMV" smpMod="SmpPerPeriod" smpRate="80" nofASDU="1" confRev="1" datSet="currentOnlysDataSet">
+							<SmvOpts sampleRate="true" dataSet="true" synchSourceId="true"/>
+						</SampledValueControl>
+					</LN0>
+					<LN prefix="L3" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L2" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="RES" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+					<LN prefix="L1" lnClass="TCTR" inst="1" lnType="Dummy.TCTR"/>
+				</LDevice>
+				<LDevice inst="VoltageTransformer">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+					<LN prefix="L3" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L2" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="RES" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+					<LN prefix="L1" lnClass="TVTR" inst="1" lnType="Dummy.TVTR"/>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<DataTypeTemplates>
+		<LNodeType lnClass="LSVS" id="Dummy.LSVS" desc="valKind=RO, valImport=true">
+			<DO name="SvCBRef" type="Dummy.ORG"/>
+			<DO name="St" type="OpenSCD_SPS_simple"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+		</LNodeType>
+		<LNodeType lnClass="LSVS" id="Dummy.LSVS1" desc="valKind=Conf, valImport=true">
+			<DO name="SvCBRef" type="Dummy.ORG1"/>
+			<DO name="LikeSvCBRef" type="Dummy.ORG1"/>
+			<DO name="St" type="OpenSCD_SPS_simple"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+		</LNodeType>
+		<LNodeType lnClass="LSVS" id="Dummy.LSVS2" desc="valKind=none, valImport=none">
+			<DO name="SvCBRef" type="Dummy.ORG2"/>
+			<DO name="St" type="OpenSCD_SPS_simple"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+		</LNodeType>
+		<LNodeType lnClass="PTRC" id="Summy.PTRC" desc="Trip conditioning: General trip signal">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="Tr" type="OpenSCD_ACT_general"/>
+			<DO name="Op" transient="true" type="OpenSCD_ACT_general"/>
+			<DO name="Str" type="OpenSCD_ACD_general"/>
+		</LNodeType>
+		<LNodeType lnClass="TVTR" id="Dummy.TVTR" desc="Voltage transformer">
+			<DO name="Rat" type="Dummy.ASG"/>
+			<DO name="VRtgSec" type="Dummy.ING"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="VolSv" type="OpenSCD_SAV_VolSv_TVTR"/>
+			<DO name="VRtg" type="OpenSCD_ASG_VRtg_TVTR"/>
+			<DO name="HzRtg" type="OpenSCD_ASG_HzRtg_TCTR"/>
+		</LNodeType>
+		<LNodeType lnClass="TCTR" id="Dummy.TCTR" desc="Current transformer">
+			<DO name="Rat" type="Dummy.ASG"/>
+			<DO name="ARtgSec" type="Dummy.ING"/>
+			<DO name="ARtgNom" type="OpenSCD_ASG_ATrg_TCTR"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="AmpSv" type="OpenSCD_SAV_AmpSv_TCTR"/>
+			<DO name="ARtg" type="OpenSCD_ASG_ATrg_TCTR"/>
+			<DO name="HzRtg" type="OpenSCD_ASG_HzRtg_TCTR"/>
+		</LNodeType>
+		<LNodeType lnClass="LLN0" id="Dummy.LLN0" desc="Logical device LN: parent">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+		</LNodeType>
+		<DOType cdc="ORG" id="Dummy.ORG">
+			<DA name="setSrcRef" bType="ObjRef" dchg="true" valKind="RO" valImport="true" fc="SP"/>
+		</DOType>
+		<DOType cdc="ORG" id="Dummy.ORG1">
+			<DA name="setSrcRef" bType="ObjRef" dchg="true" valKind="Conf" valImport="true" fc="SP"/>
+		</DOType>
+		<DOType cdc="ORG" id="Dummy.ORG2">
+			<DA name="setSrcRef" bType="ObjRef" dchg="true" fc="SP"/>
+		</DOType>
+		<DOType cdc="ACD" id="OpenSCD_ACD_general">
+			<DA name="general" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="dirGeneral" bType="Enum" dchg="true" type="FaultDirectionKind" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ACT" id="OpenSCD_ACT_general">
+			<DA name="general" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType id="Dummy.ASG" cdc="ASG">
+			<DA name="setMag" bType="Struct" type="Dummy.AnVal32" fc="SP" dchg="true"/>
+			<DA name="q" bType="Quality" fc="SP" qchg="true"/>
+			<DA name="t" bType="Timestamp" fc="SP"/>
+		</DOType>
+		<DOType cdc="ING" id="Dummy.ING">
+			<DA name="setVal" bType="INT32" dchg="true" fc="SP"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="ASG" id="OpenSCD_ASG_VRtg_TVTR">
+			<DA name="setMag" bType="Struct" type="Dummy.AnVal32" fc="SP"/>
+			<DA name="units" bType="Struct" dchg="true" type="OpenSCD_Unit_V" fc="CF"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="SAV" id="OpenSCD_SAV_VolSv_TVTR">
+			<DA name="instMag" bType="Struct" type="OpenSCD_AnalogueValue_INT32" fc="MX"/>
+			<DA name="q" bType="Quality" qchg="true" fc="MX"/>
+			<DA name="t" bType="Timestamp" fc="MX"/>
+			<DA name="units" bType="Struct" dchg="true" type="Unit" fc="CF"/>
+			<DA name="sVC" bType="Struct" dchg="true" type="OpenSCD_ScaledValueConfig_VolSv" fc="CF"/>
+		</DOType>
+		<DOType cdc="ASG" id="OpenSCD_ASG_HzRtg_TCTR">
+			<DA name="setMag" bType="Struct" type="OpenSCD_AnalogueValue_INT32" fc="SP"/>
+			<DA name="units" bType="Struct" dchg="true" type="OpenSCD_Unit_Hz" fc="CF"/>
+			<DA name="sVC" bType="Struct" dchg="true" type="ScaledValueConfig" fc="CF"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ASG" id="OpenSCD_ASG_ATrg_TCTR">
+			<DA name="setMag" bType="Struct" type="Dummy.AnVal32" fc="SP"/>
+			<DA name="units" bType="Struct" dchg="true" type="OpenSCD_Unit_A" fc="CF"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="SAV" id="OpenSCD_SAV_AmpSv_TCTR">
+			<DA name="instMag" bType="Struct" type="OpenSCD_AnalogueValue_INT32" fc="MX"/>
+			<DA name="q" bType="Quality" qchg="true" fc="MX"/>
+			<DA name="t" bType="Timestamp" fc="MX"/>
+			<DA name="units" bType="Struct" dchg="true" type="Unit" fc="CF"/>
+			<DA name="sVC" bType="Struct" dchg="true" type="OpenSCD_ScaledValueConfig_AmpSv" fc="CF"/>
+		</DOType>
+		<DOType cdc="LPL" id="OpenSCD_LPL_noLD">
+			<DA name="vendor" bType="VisString255" fc="DC"/>
+			<DA name="swRev" bType="VisString255" fc="DC"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+			<DA name="configRev" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="SPS" id="OpenSCD_SPS_simple">
+			<DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="LPL" id="OpenSCD_LPL_LD">
+			<DA name="vendor" bType="VisString255" fc="DC"/>
+			<DA name="swRev" bType="VisString255" fc="DC"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+			<DA name="configRev" bType="VisString255" fc="DC"/>
+			<DA name="ldNs" bType="VisString255" fc="EX">
+				<Val>IEC 61850-7-4:2007B4</Val>
+			</DA>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_ENS_Health">
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="HealthKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_ENS_Beh">
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ENC" id="OpenSCD_ENC_Mod">
+			<DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+				<Val>sbo-with-enhanced-security</Val>
+			</DA>
+			<DA name="sboTimeout" bType="INT32U" fc="CF">
+				<Val>30000</Val>
+			</DA>
+			<DA name="operTimeout" bType="INT32U" fc="CF">
+				<Val>600</Val>
+			</DA>
+			<DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+			<DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+			<DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_BehaviourModeKind"/>
+		</DOType>
+		<DAType id="Dummy.AnVal32">
+			<BDA name="f" bType="FLOAT32"/>
+		</DAType>
+		<DAType id="OpenSCD_Unit_V">
+			<BDA name="SIUnit" bType="Enum" type="SIUnitKind">
+				<Val>A</Val>
+			</BDA>
+		</DAType>
+		<DAType id="OpenSCD_ScaledValueConfig_VolSv">
+			<BDA name="scaleFactor" bType="FLOAT32">
+				<Val>0.01</Val>
+			</BDA>
+			<BDA name="offset" bType="FLOAT32">
+				<Val>0</Val>
+			</BDA>
+		</DAType>
+		<DAType id="OpenSCD_Unit_Hz">
+			<BDA name="SIUnit" bType="Enum" type="SIUnitKind">
+				<Val>Hz</Val>
+			</BDA>
+		</DAType>
+		<DAType id="ScaledValueConfig">
+			<BDA name="scaleFactor" bType="FLOAT32"/>
+			<BDA name="offset" bType="FLOAT32"/>
+		</DAType>
+		<DAType id="OpenSCD_Unit_A">
+			<BDA name="SIUnit" bType="Enum" type="SIUnitKind">
+				<Val>A</Val>
+			</BDA>
+		</DAType>
+		<DAType id="OpenSCD_ScaledValueConfig_AmpSv">
+			<BDA name="scaleFactor" bType="FLOAT32">
+				<Val>0.001</Val>
+			</BDA>
+			<BDA name="offset" bType="FLOAT32">
+				<Val>0</Val>
+			</BDA>
+		</DAType>
+		<DAType id="Unit">
+			<BDA name="SIUnit" bType="Enum" type="SIUnitKind"/>
+			<BDA name="multiplier" bType="Enum" type="MultiplierKind"/>
+		</DAType>
+		<DAType id="OpenSCD_AnalogueValue_INT32">
+			<BDA name="i" bType="INT32"/>
+		</DAType>
+		<DAType id="OpenSCD_Cancel_BehaviourModeKind">
+			<BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_OperSBOw_BehaviourModeKind">
+			<BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<BDA name="Check" bType="Check"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_Originator">
+			<BDA name="orCat" bType="Enum" type="OriginatorCategoryKind"/>
+			<BDA name="orIdent" bType="Octet64"/>
+		</DAType>
+		<EnumType id="FaultDirectionKind">
+			<EnumVal ord="0">unknown</EnumVal>
+			<EnumVal ord="1">forward</EnumVal>
+			<EnumVal ord="2">backward</EnumVal>
+			<EnumVal ord="3">both</EnumVal>
+		</EnumType>
+		<EnumType id="MultiplierKind">
+			<EnumVal ord="-24">y</EnumVal>
+			<EnumVal ord="-21">z</EnumVal>
+			<EnumVal ord="-18">a</EnumVal>
+			<EnumVal ord="-15">f</EnumVal>
+			<EnumVal ord="-12">p</EnumVal>
+			<EnumVal ord="-9">n</EnumVal>
+			<EnumVal ord="-6">µ</EnumVal>
+			<EnumVal ord="-3">m</EnumVal>
+			<EnumVal ord="-2">c</EnumVal>
+			<EnumVal ord="-1">d</EnumVal>
+			<EnumVal ord="0"/>
+			<EnumVal ord="1">da</EnumVal>
+			<EnumVal ord="2">h</EnumVal>
+			<EnumVal ord="3">k</EnumVal>
+			<EnumVal ord="6">M</EnumVal>
+			<EnumVal ord="9">G</EnumVal>
+			<EnumVal ord="12">T</EnumVal>
+			<EnumVal ord="15">P</EnumVal>
+			<EnumVal ord="18">E</EnumVal>
+			<EnumVal ord="21">Z</EnumVal>
+			<EnumVal ord="24">Y</EnumVal>
+		</EnumType>
+		<EnumType id="SIUnitKind">
+			<EnumVal ord="1"/>
+			<EnumVal ord="2">m</EnumVal>
+			<EnumVal ord="3">kg</EnumVal>
+			<EnumVal ord="4">s</EnumVal>
+			<EnumVal ord="5">A</EnumVal>
+			<EnumVal ord="6">K</EnumVal>
+			<EnumVal ord="7">mol</EnumVal>
+			<EnumVal ord="8">cd</EnumVal>
+			<EnumVal ord="9">deg</EnumVal>
+			<EnumVal ord="10">rad</EnumVal>
+			<EnumVal ord="11">sr</EnumVal>
+			<EnumVal ord="21">Gy</EnumVal>
+			<EnumVal ord="22">Bq</EnumVal>
+			<EnumVal ord="23">°C</EnumVal>
+			<EnumVal ord="24">Sv</EnumVal>
+			<EnumVal ord="25">F</EnumVal>
+			<EnumVal ord="26">C</EnumVal>
+			<EnumVal ord="27">S</EnumVal>
+			<EnumVal ord="28">H</EnumVal>
+			<EnumVal ord="29">V</EnumVal>
+			<EnumVal ord="30">ohm</EnumVal>
+			<EnumVal ord="31">J</EnumVal>
+			<EnumVal ord="32">N</EnumVal>
+			<EnumVal ord="33">Hz</EnumVal>
+			<EnumVal ord="34">lx</EnumVal>
+			<EnumVal ord="35">Lm</EnumVal>
+			<EnumVal ord="36">Wb</EnumVal>
+			<EnumVal ord="37">T</EnumVal>
+			<EnumVal ord="38">W</EnumVal>
+			<EnumVal ord="39">Pa</EnumVal>
+			<EnumVal ord="41">m²</EnumVal>
+			<EnumVal ord="42">m³</EnumVal>
+			<EnumVal ord="43">m/s</EnumVal>
+			<EnumVal ord="44">m/s²</EnumVal>
+			<EnumVal ord="45">m³/s</EnumVal>
+			<EnumVal ord="46">m/m³</EnumVal>
+			<EnumVal ord="47">M</EnumVal>
+			<EnumVal ord="48">kg/m³</EnumVal>
+			<EnumVal ord="49">m²/s</EnumVal>
+			<EnumVal ord="50">W/m K</EnumVal>
+			<EnumVal ord="51">J/K</EnumVal>
+			<EnumVal ord="52">ppm</EnumVal>
+			<EnumVal ord="53">1/s</EnumVal>
+			<EnumVal ord="54">rad/s</EnumVal>
+			<EnumVal ord="55">W/m²</EnumVal>
+			<EnumVal ord="56">J/m²</EnumVal>
+			<EnumVal ord="57">S/m</EnumVal>
+			<EnumVal ord="58">K/s</EnumVal>
+			<EnumVal ord="59">Pa/s</EnumVal>
+			<EnumVal ord="60">J/kg K</EnumVal>
+			<EnumVal ord="61">VA</EnumVal>
+			<EnumVal ord="62">Watts</EnumVal>
+			<EnumVal ord="63">VAr</EnumVal>
+			<EnumVal ord="64">phi</EnumVal>
+			<EnumVal ord="65">cos(phi)</EnumVal>
+			<EnumVal ord="66">Vs</EnumVal>
+			<EnumVal ord="67">V²</EnumVal>
+			<EnumVal ord="68">As</EnumVal>
+			<EnumVal ord="69">A²</EnumVal>
+			<EnumVal ord="70">A²t</EnumVal>
+			<EnumVal ord="71">VAh</EnumVal>
+			<EnumVal ord="72">Wh</EnumVal>
+			<EnumVal ord="73">VArh</EnumVal>
+			<EnumVal ord="74">V/Hz</EnumVal>
+			<EnumVal ord="75">Hz/s</EnumVal>
+			<EnumVal ord="76">char</EnumVal>
+			<EnumVal ord="77">char/s</EnumVal>
+			<EnumVal ord="78">kgm²</EnumVal>
+			<EnumVal ord="79">dB</EnumVal>
+			<EnumVal ord="80">J/Wh</EnumVal>
+			<EnumVal ord="81">W/s</EnumVal>
+			<EnumVal ord="82">l/s</EnumVal>
+			<EnumVal ord="83">dBm</EnumVal>
+			<EnumVal ord="84">h</EnumVal>
+			<EnumVal ord="85">min</EnumVal>
+			<EnumVal ord="86">Ohm/m</EnumVal>
+			<EnumVal ord="87">percent/s</EnumVal>
+		</EnumType>
+		<EnumType id="HealthKind">
+			<EnumVal ord="1">Ok</EnumVal>
+			<EnumVal ord="2">Warning</EnumVal>
+			<EnumVal ord="3">Alarm</EnumVal>
+		</EnumType>
+		<EnumType id="CtlModelKind">
+			<EnumVal ord="0">status-only</EnumVal>
+			<EnumVal ord="1">direct-with-normal-security</EnumVal>
+			<EnumVal ord="2">sbo-with-normal-security</EnumVal>
+			<EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+			<EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
+		</EnumType>
+		<EnumType id="BehaviourModeKind">
+			<EnumVal ord="1">on</EnumVal>
+			<EnumVal ord="2">blocked</EnumVal>
+			<EnumVal ord="3">test</EnumVal>
+			<EnumVal ord="4">test/blocked</EnumVal>
+			<EnumVal ord="5">off</EnumVal>
+		</EnumType>
+		<EnumType id="OriginatorCategoryKind">
+			<EnumVal ord="0">not-supported</EnumVal>
+			<EnumVal ord="1">bay-control</EnumVal>
+			<EnumVal ord="2">station-control</EnumVal>
+			<EnumVal ord="3">remote-control</EnumVal>
+			<EnumVal ord="4">automatic-bay</EnumVal>
+			<EnumVal ord="5">automatic-station</EnumVal>
+			<EnumVal ord="6">automatic-remote</EnumVal>
+			<EnumVal ord="7">maintenance</EnumVal>
+			<EnumVal ord="8">process</EnumVal>
+		</EnumType>
+	</DataTypeTemplates>
+</SCL>
+
+`;

--- a/tLN/removeSubscriptionSupervision.spec.ts
+++ b/tLN/removeSubscriptionSupervision.spec.ts
@@ -1,0 +1,471 @@
+import { expect } from "chai";
+
+import {
+  gooseSubscriptionEd2,
+  svSubscriptionEd2,
+} from "./removeSubscription.testfiles.js";
+import { findElement } from "../foundation/helpers.test.js";
+
+import { removeSubscriptionSupervision } from "./removeSubscriptionSupervision.js";
+import { Insert, isInsert, isRemove } from "../foundation/utils.js";
+
+const docEd2Goose = findElement(gooseSubscriptionEd2) as XMLDocument;
+
+const docEd2Sv = findElement(svSubscriptionEd2) as XMLDocument;
+
+describe("Function to remove supervisions (removeSubscription)", () => {
+  describe("For GOOSE", () => {
+    describe("Only allows supervision removal if declared with valKind/valImport on DTTs/instances", () => {
+      it("does not return any action if neither declared", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber4"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+
+      it("allows removals if declared on DTTs with valKind=Conf/valImport=true", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber4"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][daName="stVal"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.not.equal(0);
+      });
+
+      it("allows removals if declared on DTTs with valKind=RO/valImport=true", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber4"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"][srcCBName="GOOSE1"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.not.equal(0);
+      });
+
+      it("allows removals if declared on first instantiated element with valKind=Conf/valImport=true", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber5"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][daName="stVal"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.not.equal(0);
+      });
+
+      it("does not allow removals with only valKind=RO/Conf", () => {
+        const extRef1 = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber6"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][daName="stVal"]`
+        )!;
+        const edits1 = removeSubscriptionSupervision(extRef1);
+        expect(edits1.length).to.equal(0);
+
+        const extRef2 = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber6"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"][srcCBName="GOOSE1"]`
+        )!;
+        const edits2 = removeSubscriptionSupervision(extRef2);
+        expect(edits2.length).to.equal(0);
+      });
+
+      it("does not allow removals with only valImport=true", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber7"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+    });
+
+    describe("Does not error on remove supervision with invalid entries if", () => {
+      it("ExtRef has no srcXXX attributes", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber2"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][intAddr="NoSrcAttrs"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+
+      it("the referenced GSEControl does not exist", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber2"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][intAddr="IncorrectGSEControl"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+
+      it("there is no supervision instance to remove them for", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+    });
+
+    describe("Allows removal of control block references", () => {
+      it("for an ExtRef pointing to a supervision LN", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber1"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"]`
+        )!;
+
+        const edits = removeSubscriptionSupervision(extRef);
+
+        expect(edits.length).to.equal(2);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+      });
+
+      it("for multiple GOOSE ExtRefs with the same supervision instance", () => {
+        const extRef = Array.from(
+          docEd2Goose.querySelectorAll(
+            `IED[name="GOOSE_Subscriber3"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][doName="Pos"]`
+          )
+        )!;
+
+        const edits = removeSubscriptionSupervision(extRef);
+
+        expect(edits.length).to.equal(2);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+      });
+
+      it("for multiple GOOSE ExtRefs with different supervision instances", () => {
+        const extRef1 = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber3"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][doName="Pos"][srcCBName="GOOSE1"]`
+        )!;
+        const extRef2 = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber3"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][doName="Pos"][srcCBName="GOOSE2"]`
+        )!;
+
+        const edits = removeSubscriptionSupervision([extRef1, extRef2]);
+
+        expect(edits.length).to.equal(4);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE1"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+
+        expect(isRemove(edits[2])).to.be.true;
+        expect(edits[2].node.nodeName).to.be.equal("Val");
+        expect(edits[2].node.textContent).to.be.equal(
+          "GOOSE_Publisher2QB2_Disconnector/LLN0.GOOSE2"
+        );
+
+        expect(isInsert(edits[3])).to.be.true;
+        expect(edits[3].node.nodeName).to.be.equal("Val");
+        expect(edits[3].node.textContent).to.be.equal("");
+        expect((<Insert>edits[3]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[3]).reference).to.be.null;
+      });
+
+      it("even if it is the first supervision instance", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber1"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+
+        expect(edits.length).to.equal(2);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+      });
+    });
+
+    describe("Allows removal of supervision LNs with the removeLN option", () => {
+      it("For a supervision LN", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber4"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher2"][daName="stVal"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef, { removeLN: true });
+
+        expect(edits.length).to.equal(1);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("LN");
+        expect((<Element>edits[0].node).getAttribute("inst")).to.be.equal("2");
+      });
+
+      it("except if it is not the first supervision LN (returns Val)", () => {
+        const extRef = docEd2Goose.querySelector(
+          `IED[name="GOOSE_Subscriber5"] LDevice[inst="Earth_Switch"] Inputs > ExtRef[iedName="GOOSE_Publisher"][daName="stVal"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef, { removeLN: true });
+
+        expect(edits.length).to.equal(2);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "GOOSE_PublisherQB2_Disconnector/LLN0.GOOSE2"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+      });
+    });
+  });
+
+  describe("For SV", () => {
+    describe("Only allows supervision removal if declared with valKind/valImport on DTTs/instances", () => {
+      it("does not return any action if neither declared", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber4"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+
+      it("allows removals if declared on DTTs with valKind=Conf/valImport=true", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber4"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher2"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.not.equal(0);
+      });
+
+      it("allows removals if declared on DTTs with valKind=RO/valImport=true", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber4"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.not.equal(0);
+      });
+
+      it("allows removals if declared on first instantiated element with valKind=Conf/valImport=true", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber5"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.not.equal(0);
+      });
+
+      it("does not allow removals with only valKind=RO/Conf", () => {
+        const extRef1 = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber6"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef1);
+        expect(edits.length).to.equal(0);
+
+        const extRef2 = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber6"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher2"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+        const edits2 = removeSubscriptionSupervision(extRef2);
+        expect(edits2.length).to.equal(0);
+      });
+
+      it("does not allow removals with only valImport=true", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber7"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+    });
+
+    describe("Does not error on remove supervision with invalid entries if", () => {
+      it("ExtRef has no srcXXX attributes", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber2"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="AmpSv;TCTR1/AmpSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+
+      it("the referenced SampledValueControl does not exist", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber2"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher2"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+
+      it("there is no supervision instance to remove them for", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher2"][intAddr="AmpSv;TCTR1/AmpSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef);
+        expect(edits.length).to.equal(0);
+      });
+    });
+
+    describe("Allows removal of control block references", () => {
+      it("for an ExtRef pointing to a supervision LN", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+
+        const edits = removeSubscriptionSupervision(extRef);
+
+        expect(edits.length).to.equal(2);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "SMV_PublisherCurrentTransformer/LLN0.currentOnly"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+      });
+
+      it("for multiple ExtRefs with the same supervision instance", () => {
+        const extRefs = Array.from(
+          docEd2Sv.querySelectorAll(
+            `IED[name="SMV_Subscriber3"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher"][srcCBName="currentOnly"]`
+          )
+        )!;
+
+        const edits = removeSubscriptionSupervision(extRefs);
+
+        expect(edits.length).to.equal(2);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "SMV_PublisherCurrentTransformer/LLN0.currentOnly"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+      });
+
+      it("for multiple ExtRefs with different supervision instances", () => {
+        const extRef1 = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber3"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher"][srcCBName="fullSmv"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+        const extRef2 = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber3"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher2"][srcCBName="currentOnly"][intAddr="AmpSv;TCTR2/AmpSv/instMag.i"]`
+        )!;
+
+        const edits = removeSubscriptionSupervision([extRef1, extRef2]);
+
+        expect(edits.length).to.equal(4);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "SMV_PublisherCurrentTransformer/LLN0.fullSmv"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+
+        expect(isRemove(edits[2])).to.be.true;
+        expect(edits[2].node.nodeName).to.be.equal("Val");
+        expect(edits[2].node.textContent).to.be.equal(
+          "SMV_Publisher2CurrentTransformer/LLN0.currentOnly"
+        );
+
+        expect(isInsert(edits[3])).to.be.true;
+        expect(edits[3].node.nodeName).to.be.equal("Val");
+        expect(edits[3].node.textContent).to.be.equal("");
+        expect((<Insert>edits[3]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[3]).reference).to.be.null;
+      });
+
+      it("even if it is the first supervision instance", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber3"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher2"][srcCBName="currentOnly"][intAddr="AmpSv;TCTR2/AmpSv/instMag.i"]`
+        )!;
+
+        const edits = removeSubscriptionSupervision(extRef);
+
+        expect(edits.length).to.equal(2);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "SMV_Publisher2CurrentTransformer/LLN0.currentOnly"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+      });
+    });
+
+    describe("Allows removal of supervision LNs with the removeLN option", () => {
+      it("For a supervision LN", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber4"] LDevice[inst="Overcurrent"] Inputs > ExtRef[iedName="SMV_Publisher2"][srcCBName="currentOnly"][intAddr="AmpSv;TCTR3/AmpSv/instMag.i"]`
+        )!;
+        const edits = removeSubscriptionSupervision(extRef, { removeLN: true });
+
+        expect(edits.length).to.equal(1);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("LN");
+        expect((<Element>edits[0].node).getAttribute("inst")).to.be.equal("2");
+      });
+
+      it("except if it is not the first supervision LN (returns Val)", () => {
+        const extRef = docEd2Sv.querySelector(
+          `IED[name="SMV_Subscriber5"] LDevice[inst="Overvoltage"] Inputs > ExtRef[iedName="SMV_Publisher"][intAddr="VolSv;TVTR1/VolSv/instMag.i"]`
+        )!;
+
+        const edits = removeSubscriptionSupervision(extRef, { removeLN: true });
+
+        expect(edits.length).to.equal(2);
+
+        expect(isRemove(edits[0])).to.be.true;
+        expect(edits[0].node.nodeName).to.be.equal("Val");
+        expect(edits[0].node.textContent).to.be.equal(
+          "SMV_PublisherCurrentTransformer/LLN0.voltageOnly"
+        );
+
+        expect(isInsert(edits[1])).to.be.true;
+        expect(edits[1].node.nodeName).to.be.equal("Val");
+        expect(edits[1].node.textContent).to.be.equal("");
+        expect((<Insert>edits[1]).parent.nodeName).to.be.equal("DAI");
+        expect((<Insert>edits[1]).reference).to.be.null;
+      });
+    });
+  });
+});


### PR DESCRIPTION
* Fix supervision function selector scoping (closes #6)
* Allow only CB or LN removal for subscription supervision removal (closes #18)

<s>WIP, still to do:

* SV tests
* Tests `for canRemoveSubscriptionSupervision`</s>

This breaks the previous API. Subscription removal only either removes the LN or the `textContent` of the `Val` element. OpenSCD created supervision elements are not treated in any special way.
Additionally the first supervision in the data model cannot be removed (and trying only yields removal of the `textContent` of the `Val` element).

<s>I'll complete this soon if this seems like the correct direction @JakobVogelsang </s>