### PR TITLE
fix(importIed): prevent schema isseus and orphan types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Function library supporting SCL editing",
   "license": "Apache-2.0",
   "author": "Jakob Vogelsang",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/tIED/importIED/multipleieds.scd
+++ b/tIED/importIED/multipleieds.scd
@@ -561,10 +561,10 @@
 			<DA fc="DC" name="d" bType="VisString255" />
 		</DOType>
 		<DOType cdc="SPS" id="Dummy.SPS">
-            <DA fc="ST" dchg="true" name="stVal" bType="BOOLEAN" />
-            <DA fc="ST" qchg="true" name="q" bType="Quality" />
-            <DA fc="ST" name="t" bType="Timestamp" />
-        </DOType>
+			<DA fc="ST" dchg="true" name="stVal" bType="BOOLEAN" />
+			<DA fc="ST" qchg="true" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+		</DOType>
 		<DAType id="AnalogueValue_i">
             <BDA name="i" bType="INT32"/>
         </DAType>

--- a/tIED/importIED/valid.iid
+++ b/tIED/importIED/valid.iid
@@ -433,43 +433,21 @@
 			<BDA name="Test" bType="BOOLEAN" />
 		</DAType>
 		<EnumType id="Dummy_ctlModel">
-			<EnumVal ord="0">
-				status-only
-			</EnumVal>
-			<EnumVal ord="1">
-				direct-with-normal-security
-			</EnumVal>
-			<EnumVal ord="2">
-				sbo-with-normal-security
-			</EnumVal>
-			<EnumVal ord="3">
-				direct-with-enhanced-security
-			</EnumVal>
-			<EnumVal ord="4">
-				sbo-with-enhanced-security
-			</EnumVal>
+			<EnumVal ord="0">status-only</EnumVal>
+			<EnumVal ord="1">direct-with-normal-security</EnumVal>
+			<EnumVal ord="2">sbo-with-normal-security</EnumVal>
+			<EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+			<EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
 		</EnumType>
 		<EnumType id="unreferened.EnumType">
-			<EnumVal ord="0">
-				status-only
-			</EnumVal>
+			<EnumVal ord="0">status-only</EnumVal>
 		</EnumType>
 		<EnumType id="Dummy_Beh">
-			<EnumVal ord="1">
-				on
-			</EnumVal>
-			<EnumVal ord="2">
-				blocked
-			</EnumVal>
-			<EnumVal ord="3">
-				test
-			</EnumVal>
-			<EnumVal ord="4">
-				test/blocked
-			</EnumVal>
-			<EnumVal ord="5">
-				off
-			</EnumVal>
+			<EnumVal ord="1">on</EnumVal>
+			<EnumVal ord="2">blocked</EnumVal>
+			<EnumVal ord="3">test</EnumVal>
+			<EnumVal ord="4">test/blocked</EnumVal>
+			<EnumVal ord="5">off</EnumVal>
 		</EnumType>
 		<EnumType id="Dummy_Health">
 			<EnumVal ord="1">Ok</EnumVal>
@@ -477,33 +455,15 @@
 			<EnumVal ord="3">Alarm</EnumVal>
 		</EnumType>
 		<EnumType id="Dummy_orCategory">
-			<EnumVal ord="0">
-				not-supported
-			</EnumVal>
-			<EnumVal ord="1">
-				bay-control
-			</EnumVal>
-			<EnumVal ord="2">
-				station-control
-			</EnumVal>
-			<EnumVal ord="3">
-				remote-control
-			</EnumVal>
-			<EnumVal ord="4">
-				automatic-bay
-			</EnumVal>
-			<EnumVal ord="5">
-				automatic-station
-			</EnumVal>
-			<EnumVal ord="6">
-				automatic-remote
-			</EnumVal>
-			<EnumVal ord="7">
-				maintenance
-			</EnumVal>
-			<EnumVal ord="8">
-				process
-			</EnumVal>
+			<EnumVal ord="0">not-supported</EnumVal>
+			<EnumVal ord="1">bay-control</EnumVal>
+			<EnumVal ord="2">station-control</EnumVal>
+			<EnumVal ord="3">remote-control</EnumVal>
+			<EnumVal ord="4">automatic-bay</EnumVal>
+			<EnumVal ord="5">automatic-station</EnumVal>
+			<EnumVal ord="6">automatic-remote</EnumVal>
+			<EnumVal ord="7">maintenance</EnumVal>
+			<EnumVal ord="8">process</EnumVal>
 		</EnumType>
 	</DataTypeTemplates>
 </SCL>

--- a/tIED/insertIED.ts
+++ b/tIED/insertIED.ts
@@ -227,7 +227,7 @@ function addLNodeType(
     Array.from(
       newIed.querySelectorAll(`LN0[lnType="${idOld}"],LN[lnType="${idOld}"]`)
     )
-      .filter((anyLn) => anyLn.closest("Private"))
+      .filter((anyLn) => !anyLn.closest("Private"))
       .forEach((ln) => ln.setAttribute("lnType", idNew));
   }
 
@@ -239,45 +239,48 @@ function addLNodeType(
 }
 
 function addDataTypeTemplates(newIed: Element, scl: Element): Insert[] {
-  const edits: (Insert | undefined)[] = [];
+  const dataTypeEdit: Insert[] = [];
 
   const dataTypeTemplates = scl.querySelector(":root > DataTypeTemplates")
     ? scl.querySelector(":root > DataTypeTemplates")!
     : createElement(scl.ownerDocument, "DataTypeTemplates", {});
 
   if (!dataTypeTemplates.parentElement) {
-    edits.push({
+    dataTypeEdit.push({
       parent: scl,
       node: dataTypeTemplates,
       reference: getReference(scl, "DataTypeTemplates"),
     });
   }
 
+  const typeEdits: (Insert | undefined)[] = [];
   newIed.ownerDocument
-    .querySelectorAll(":root > DataTypeTemplates > LNodeType")
-    .forEach((lNodeType) =>
-      edits.push(addLNodeType(newIed, lNodeType, dataTypeTemplates!))
-    );
-
-  newIed.ownerDocument
-    .querySelectorAll(":root > DataTypeTemplates > DOType")
-    .forEach((doType) =>
-      edits.push(addDOType(newIed, doType, dataTypeTemplates!))
+    .querySelectorAll(":root > DataTypeTemplates > EnumType")
+    .forEach((enumType) =>
+      typeEdits.push(addEnumType(newIed, enumType, dataTypeTemplates!))
     );
 
   newIed.ownerDocument
     .querySelectorAll(":root > DataTypeTemplates > DAType")
     .forEach((daType) =>
-      edits.push(addDAType(newIed, daType, dataTypeTemplates!))
+      typeEdits.push(addDAType(newIed, daType, dataTypeTemplates!))
     );
 
   newIed.ownerDocument
-    .querySelectorAll(":root > DataTypeTemplates > EnumType")
-    .forEach((enumType) =>
-      edits.push(addEnumType(newIed, enumType, dataTypeTemplates!))
+    .querySelectorAll(":root > DataTypeTemplates > DOType")
+    .forEach((doType) =>
+      typeEdits.push(addDOType(newIed, doType, dataTypeTemplates!))
     );
 
-  return edits.filter((item) => item !== undefined) as Insert[];
+  newIed.ownerDocument
+    .querySelectorAll(":root > DataTypeTemplates > LNodeType")
+    .forEach((lNodeType) =>
+      typeEdits.push(addLNodeType(newIed, lNodeType, dataTypeTemplates!))
+    );
+
+  return dataTypeEdit.concat(
+    typeEdits.reverse().filter((item) => item !== undefined) as Insert[]
+  );
 }
 
 function isNameUnique(scl: Element, ied: Element): boolean {


### PR DESCRIPTION
Closes #49 

The obvious fix was in addLNodeType.... Here we filtered for anyLn.closest('Private') which is filtering all elements. 
The bigger changes are managing the import from bottom-up compared to top-down. This prevents to have orphans data types after importing IEDs.