### PR TITLE
Check supervision creation without passing a control block (closes #80).

### DIFF
--- a/tExtRef/doesFcdaMeetExtRefRestrictions.spec.ts
+++ b/tExtRef/doesFcdaMeetExtRefRestrictions.spec.ts
@@ -50,7 +50,7 @@ describe("Function compare FCDA basic types to ExtRef restrictions", () => {
     const extRef = findElement(extRefXSWIPosDbPos, "ExtRef") as Element;
 
     expect(
-      doesFcdaMeetExtRefRestrictions(extRef, fcda, { controlBlockType: "SMV" })
+      doesFcdaMeetExtRefRestrictions(extRef, fcda, { controlBlockType: "SMV" }),
     ).to.be.false;
   });
 
@@ -61,7 +61,7 @@ describe("Function compare FCDA basic types to ExtRef restrictions", () => {
     expect(
       doesFcdaMeetExtRefRestrictions(extRef, fcda, {
         controlBlockType: "GOOSE",
-      })
+      }),
     ).to.be.false;
   });
 
@@ -72,21 +72,21 @@ describe("Function compare FCDA basic types to ExtRef restrictions", () => {
     expect(
       doesFcdaMeetExtRefRestrictions(extRef, fcda, {
         controlBlockType: "GOOSE",
-      })
+      }),
     ).to.be.false;
   });
 
   it("returns false with not matching cdc", () => {
     const fcda = findElement(
       publisherIED,
-      `FCDA[desc="USERENSnull"]`
+      `FCDA[desc="USERENSnull"]`,
     ) as Element;
     const extRef = findElement(extRefPos, "ExtRef") as Element;
 
     expect(
       doesFcdaMeetExtRefRestrictions(extRef, fcda, {
         controlBlockType: "GOOSE",
-      })
+      }),
     ).to.be.false;
   });
 
@@ -97,35 +97,35 @@ describe("Function compare FCDA basic types to ExtRef restrictions", () => {
     expect(
       doesFcdaMeetExtRefRestrictions(extRef, fcda, {
         controlBlockType: "GOOSE",
-      })
+      }),
     ).to.be.false;
   });
 
   it("returns false with not matching bType", () => {
     const fcda = findElement(
       publisherIED,
-      `FCDA[desc="USERENSstVal"]`
+      `FCDA[desc="USERENSstVal"]`,
     ) as Element;
     const extRef = findElement(extRefBehstVal, "ExtRef") as Element;
 
     expect(
       doesFcdaMeetExtRefRestrictions(extRef, fcda, {
         controlBlockType: "GOOSE",
-      })
+      }),
     ).to.be.false;
   });
 
   it("returns true for matching types CMV/FLOAT32 ", () => {
     const fcda = findElement(
       publisherIED,
-      `FCDA[desc="CMVFLOAT32"]`
+      `FCDA[desc="CMVFLOAT32"]`,
     ) as Element;
     const extRef = findElement(extRefCMVFLOAT32, "ExtRef") as Element;
 
     expect(
       doesFcdaMeetExtRefRestrictions(extRef, fcda, {
         controlBlockType: "Report",
-      })
+      }),
     ).to.be.true;
   });
 
@@ -136,7 +136,7 @@ describe("Function compare FCDA basic types to ExtRef restrictions", () => {
     expect(
       doesFcdaMeetExtRefRestrictions(extRef, fcda, {
         controlBlockType: "GOOSE",
-      })
+      }),
     ).to.be.true;
   });
 
@@ -155,7 +155,7 @@ describe("Function compare FCDA basic types to ExtRef restrictions", () => {
     expect(
       doesFcdaMeetExtRefRestrictions(extRef, fcda, {
         checkOnlyBType: true,
-      })
+      }),
     ).to.be.true;
   });
 });

--- a/tExtRef/doesFcdaMeetExtRefRestrictions.ts
+++ b/tExtRef/doesFcdaMeetExtRefRestrictions.ts
@@ -20,7 +20,7 @@ export type DoesFcdaMeetExtRefRestrictionsOptions = {
 export function doesFcdaMeetExtRefRestrictions(
   extRef: Element,
   fcda: Element,
-  options: DoesFcdaMeetExtRefRestrictionsOptions = { checkOnlyBType: false }
+  options: DoesFcdaMeetExtRefRestrictionsOptions = { checkOnlyBType: false },
 ): boolean {
   // Vendor does not provide data for the check so any FCDA meets restriction
   if (!extRef.hasAttribute("pDO")) return true;

--- a/tLN/supervision/canInstantiateSubscriptionSupervision.spec.ts
+++ b/tLN/supervision/canInstantiateSubscriptionSupervision.spec.ts
@@ -246,7 +246,7 @@ describe("Function that checks whether subscription supervision can be instantia
   });
 
   describe("check whether supervision logical nodes can be edited by SCT", () => {
-    describe("for GSEControl", () => {
+    describe("for GOOSE with a GSEControl", () => {
       it("return false when valImport or valKind is missing from LGOS", () => {
         const sourceControlBlock = doc.querySelector(
           'GSEControl[name="GOOSE3"]',
@@ -293,7 +293,42 @@ describe("Function that checks whether subscription supervision can be instantia
       });
     });
 
-    describe("for SampledValueControl", () => {
+    describe("for GOOSE without a GSEControl", () => {
+      it("return false when valImport or valKind is missing from LGOS", () => {
+        const subscriberIedOrLn = doc.querySelector(
+          'IED[name="SupervisionNotSupported"]',
+        )!;
+        expect(
+          canInstantiateSubscriptionSupervision({
+            subscriberIedOrLn,
+          }),
+        ).to.be.false;
+      });
+
+      it("return false when valImport or valKind is missing on selected LN", () => {
+        const lgos = doc.querySelector(
+          'IED[name="SupervisionNotSupported"]  LN[lnClass="LGOS"]',
+        )!;
+        expect(
+          canInstantiateSubscriptionSupervision({
+            subscriberIedOrLn: lgos,
+          }),
+        ).to.be.false;
+      });
+
+      it("checks for DA and DAI for valImport/valKind", () => {
+        const lsvs = doc.querySelector(
+          'IED[name="SV_Subscriber"]  LN[lnClass="LSVS"]',
+        )!;
+        expect(
+          canInstantiateSubscriptionSupervision({
+            subscriberIedOrLn: lsvs,
+          }),
+        ).to.be.true;
+      });
+    });
+
+    describe("for SV with a SampledValueControl", () => {
       it("return false when valImport or valKind is missing on the from LSVS", () => {
         const sourceControlBlock = doc.querySelector(
           'SampledValueControl[name="someSmv"]',
@@ -335,6 +370,42 @@ describe("Function that checks whether subscription supervision can be instantia
         expect(
           canInstantiateSubscriptionSupervision({
             sourceControlBlock,
+            subscriberIedOrLn: lsvs,
+          }),
+        ).to.be.true;
+      });
+    });
+
+    describe("for SV without a SampledValueControl", () => {
+      it("return false when only an IED is passed", () => {
+        const subscriberIedOrLn = doc.querySelector(
+          'IED[name="SV_Subscriber"]',
+        )!;
+
+        expect(
+          canInstantiateSubscriptionSupervision({
+            subscriberIedOrLn,
+          }),
+        ).to.be.false;
+      });
+
+      it("return false when valImport or valKind is missing on selected LN", () => {
+        const lsvs = doc.querySelector(
+          'IED[name="SV_Subscriber"] LN[lnClass="LSVS"][inst="2"]',
+        )!;
+        expect(
+          canInstantiateSubscriptionSupervision({
+            subscriberIedOrLn: lsvs,
+          }),
+        ).to.be.false;
+      });
+
+      it("checks for DA and DAI for valImport/valKind", () => {
+        const lsvs = doc.querySelector(
+          'IED[name="SV_Subscriber"]  LN[lnClass="LSVS"]',
+        )!;
+        expect(
+          canInstantiateSubscriptionSupervision({
             subscriberIedOrLn: lsvs,
           }),
         ).to.be.true;

--- a/tLN/supervision/createSupervisionEdit.ts
+++ b/tLN/supervision/createSupervisionEdit.ts
@@ -109,10 +109,11 @@ function createSupervisionLogicalNode(
   supervision: Supervision,
   controlBlockReference: string,
   inst: string,
-) {
+): Insert | null {
   const subscriberIed = supervision.subscriberIedOrLn;
+  if (!subscriberIed || !supervision.sourceControlBlock) return null;
 
-  const lnClass = supervisionLnClass(supervision);
+  const lnClass = supervisionLnClass(supervision)!;
 
   const formLn = subscriberIed.querySelector(`LN[lnClass="${lnClass}"]`)!;
   const parent = formLn.parentElement!;
@@ -205,6 +206,8 @@ export function createSupervisionEdit(
   options: CreateSupervisionOptions,
 ): Insert | null {
   const sourceControlBlock = supervision.sourceControlBlock;
+  if (!sourceControlBlock) return null;
+
   const controlBlockReference = controlBlockObjRef(sourceControlBlock);
   if (!controlBlockReference) return null;
 

--- a/tLN/supervision/foundation.spec.ts
+++ b/tLN/supervision/foundation.spec.ts
@@ -1,0 +1,21 @@
+import { expect } from "chai";
+
+import { supervision } from "./supervision.testfiles.js";
+
+import { type, supervisionLnClass } from "./foundation.js";
+
+const doc = new DOMParser().parseFromString(supervision, "application/xml");
+
+describe("Returns supervision type", () => {
+  it("returns undefined for a supervision which has no control block or correct LN", () => {
+    const element = doc.querySelector("LN0")!;
+    expect(type({ subscriberIedOrLn: element })).to.be.undefined;
+  });
+});
+
+describe("Returns supervision class", () => {
+  it("returns undefined for a supervision which has no control block or correct LN", () => {
+    const element = doc.querySelector("LN0")!;
+    expect(supervisionLnClass({ subscriberIedOrLn: element })).to.be.undefined;
+  });
+});

--- a/tLN/supervision/insertSubscriptionSupervisions.spec.ts
+++ b/tLN/supervision/insertSubscriptionSupervisions.spec.ts
@@ -47,7 +47,7 @@ describe("Functions that inserts supervision to subscription edits", () => {
 
   it("return empty array with unsufficient update edit", () => {
     const extRef1 = doc.querySelector(
-      'IED[name="GOOSE_Subscriber4"] ExtRef[intAddr="Pos.stVal"]'
+      'IED[name="GOOSE_Subscriber4"] ExtRef[intAddr="Pos.stVal"]',
     )!;
 
     const attributes1 = {};
@@ -147,7 +147,7 @@ describe("Functions that inserts supervision to subscription edits", () => {
 
   it("return array of edits for update subscription edits", () => {
     const extRef1 = doc.querySelector(
-      'IED[name="GOOSE_Subscriber4"] ExtRef[intAddr="Pos.stVal"]'
+      'IED[name="GOOSE_Subscriber4"] ExtRef[intAddr="Pos.stVal"]',
     )!;
 
     const attributes1 = {
@@ -166,7 +166,7 @@ describe("Functions that inserts supervision to subscription edits", () => {
     const update1 = { element: extRef1, attributes: attributes1 };
 
     const extRef2 = doc.querySelector(
-      'IED[name="GOOSE_Subscriber4"] ExtRef[intAddr="Pos.q"]'
+      'IED[name="GOOSE_Subscriber4"] ExtRef[intAddr="Pos.q"]',
     )!;
 
     const attributes2 = {
@@ -231,10 +231,10 @@ describe("Functions that inserts supervision to subscription edits", () => {
 
   it("return array for multiple combined update/insert edits to multiple IEDs", () => {
     const ied4e1 = doc.querySelector(
-      'IED[name="GOOSE_Subscriber4"] ExtRef[intAddr="Pos.stVal"]'
+      'IED[name="GOOSE_Subscriber4"] ExtRef[intAddr="Pos.stVal"]',
     )!;
     const ied5e1 = doc.querySelector(
-      'IED[name="GOOSE_Subscriber5"] ExtRef[intAddr="Pos.stVal"]'
+      'IED[name="GOOSE_Subscriber5"] ExtRef[intAddr="Pos.stVal"]',
     )!;
     const attributes1 = {
       iedName: "Publisher",
@@ -301,26 +301,26 @@ describe("Functions that inserts supervision to subscription edits", () => {
 
     expect(edits.length).to.equal(6);
     expect(
-      (edits[0].node as Element).querySelector("Val")?.textContent
+      (edits[0].node as Element).querySelector("Val")?.textContent,
     ).to.equal("PublisherGOOSE/LLN0.GOOSE3");
     expect(
-      (edits[1].node as Element).querySelector("Val")?.textContent
+      (edits[1].node as Element).querySelector("Val")?.textContent,
     ).to.equal("PublisherGOOSE/LLN0.GOOSE3");
     expect((edits[1].node as Element).getAttribute("inst")).to.equal("2");
     expect(
-      (edits[2].node as Element).querySelector("Val")?.textContent
+      (edits[2].node as Element).querySelector("Val")?.textContent,
     ).to.equal("PublisherGOOSE/LLN0.GOOSE5");
     expect((edits[2].node as Element).getAttribute("inst")).to.equal("4");
     expect(
-      (edits[3].node as Element).querySelector("Val")?.textContent
+      (edits[3].node as Element).querySelector("Val")?.textContent,
     ).to.equal("PublisherGOOSE/LLN0.GOOSE6");
     expect((edits[3].node as Element).getAttribute("inst")).to.equal("6");
     expect(
-      (edits[4].node as Element).querySelector("Val")?.textContent
+      (edits[4].node as Element).querySelector("Val")?.textContent,
     ).to.equal("PublisherGOOSE/LLN0.GOOSE5");
     expect((edits[4].node as Element).getAttribute("inst")).to.equal("3");
     expect(
-      (edits[5].node as Element).querySelector("Val")?.textContent
+      (edits[5].node as Element).querySelector("Val")?.textContent,
     ).to.equal("PublisherGOOSE/LLN0.GOOSE6");
     expect((edits[5].node as Element).getAttribute("inst")).to.equal("6");
   });

--- a/tLN/supervision/insertSubscriptionSupervisions.ts
+++ b/tLN/supervision/insertSubscriptionSupervisions.ts
@@ -17,7 +17,7 @@ import { createSupervisionEdit } from "./createSupervisionEdit.js";
  * @returns A sink IED for a given ExtRef insert or `null`*/
 function findIED(
   edit: Insert,
-  previousEdits: (Insert | Update)[]
+  previousEdits: (Insert | Update)[],
 ): Element | null {
   // case 1: Input is already in the SCL and ExtRef is added to it
   const inputs = edit.parent as Element;
@@ -26,7 +26,7 @@ function findIED(
 
   // case 2: Input element is added as part of the subscription as well.
   const inputsInsertEdit = previousEdits.find(
-    (otherEdit) => isInsert(otherEdit) && otherEdit.node === edit.parent
+    (otherEdit) => isInsert(otherEdit) && otherEdit.node === edit.parent,
   ) as Insert | undefined;
   if (inputsInsertEdit)
     return (inputsInsertEdit.parent as Element).closest("IED");
@@ -36,7 +36,7 @@ function findIED(
 }
 
 function uniqueSupervisions(
-  edits: (Insert | Update)[]
+  edits: (Insert | Update)[],
 ): Record<string, Supervision> {
   const uniqueSupervisions: Record<string, Supervision> = {};
   edits.forEach((edit) => {
@@ -75,7 +75,7 @@ function uniqueSupervisions(
 
     const controlBlock = findControlBlockBySrcAttributes(
       sink!.ownerDocument,
-      source!
+      source!,
     );
     if (!controlBlock) return;
     const controlBlockReference = controlBlockObjRef(controlBlock)!;
@@ -104,7 +104,7 @@ function uniqueSupervisions(
  * @returns Edit array adding supervision on top of the subscription
  */
 export function insertSubscriptionSupervisions(
-  edits: (Update | Insert)[]
+  edits: (Update | Insert)[],
 ): Insert[] {
   /** Global as multiple subscription could be defined for different subscriber IEDs */
   const instGenerator = globalLnInstGenerator();

--- a/tLN/supervision/instantiateSubscriptionSupervision.ts
+++ b/tLN/supervision/instantiateSubscriptionSupervision.ts
@@ -26,7 +26,11 @@ export function instantiateSubscriptionSupervision(
     checkMaxSupervisionLimits: true,
   },
 ): Insert | null {
-  if (!canInstantiateSubscriptionSupervision(supervision, options)) return null;
+  if (
+    !canInstantiateSubscriptionSupervision(supervision, options) ||
+    !supervision.sourceControlBlock
+  )
+    return null;
 
   if (options.fixedLnInst >= 0)
     return createSupervisionEdit(supervision, {


### PR DESCRIPTION
Closes #80.

I don't know if this is even a good idea, and if it is not I am happy for this PR to be closed, it is intended to explore the issue.

To be useful this would also require #79.