### PR TITLE
feat(tLN): removeSupervision

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -72,6 +72,10 @@ export {
 export { canInstantiateSubscriptionSupervision } from "./tLN/supervision/canInstantiateSubscriptionSupervision.js";
 export { instantiateSubscriptionSupervision } from "./tLN/supervision/instantiateSubscriptionSupervision.js";
 export { insertSubscriptionSupervisions } from "./tLN/supervision/insertSubscriptionSupervisions.js";
+export {
+  removeSupervisionOptions,
+  removeSupervision,
+} from "./tLN/supervision/removeSupervision.js";
 
 export { maxAttributes, canAddFCDA } from "./tFCDA/canAddFCDA.js";
 export { fcdaBaseTypes } from "./tFCDA/fcdaBaseTypes.js";

--- a/tLN/removeSubscriptionSupervision.ts
+++ b/tLN/removeSubscriptionSupervision.ts
@@ -2,6 +2,7 @@ import { Remove } from "../foundation/utils.js";
 
 import { controlBlockObjRef } from "../tControl/controlBlockObjRef.js";
 import { sourceControlBlock } from "../tExtRef/sourceControlBlock.js";
+import { isSrcRefEditable } from "./supervision/foundation.js";
 
 type GroupedExtRefs = {
   extRefs: Element[];
@@ -34,44 +35,19 @@ function removableSupervisionElement(
   return canRemoveLn ? ln : doi;
 }
 
-/** @returns Whether `DA` with name `setSrcRef`  can edited by SCL editor */
-function isSrcRefEditable(ctrlBlock: Element, subscriberIed: Element): boolean {
+/** @returns Whether `DA` with name `setSrcRef` can edited by SCL editor */
+function isSupervisionEditable(
+  ctrlBlock: Element,
+  subscriberIed: Element,
+): boolean {
   const supervisionElement = removableSupervisionElement(
     ctrlBlock,
     subscriberIed,
   );
-  const ln = supervisionElement?.closest("LN") ?? null;
-  if (!ln) return false;
+  const supervisionLn = supervisionElement?.closest("LN") ?? null;
+  if (!supervisionLn) return false;
 
-  if (
-    supervisionElement?.querySelector(
-      ':scope DAI[name="setSrcRef"][valImport="true"][valKind="RO"],' +
-        ' :scope DAI[name="setSrcRef"][valImport="true"][valKind="Conf"]',
-    )
-  )
-    return true;
-
-  const rootNode = ln.ownerDocument;
-
-  const lnClass = ln.getAttribute("lnClass");
-  const cbRefType = lnClass === "LGOS" ? "GoCBRef" : "SvCBRef";
-  const lnType = ln.getAttribute("lnType");
-
-  const goOrSvCBRef = rootNode.querySelector(
-    `DataTypeTemplates > 
-        LNodeType[id="${lnType}"][lnClass="${lnClass}"] > DO[name="${cbRefType}"]`,
-  );
-
-  const cbRefId = goOrSvCBRef?.getAttribute("type");
-  const setSrcRef = rootNode.querySelector(
-    `DataTypeTemplates > DOType[id="${cbRefId}"] > DA[name="setSrcRef"]`,
-  );
-
-  return (
-    (setSrcRef?.getAttribute("valKind") === "Conf" ||
-      setSrcRef?.getAttribute("valKind") === "RO") &&
-    setSrcRef.getAttribute("valImport") === "true"
-  );
+  return isSrcRefEditable(supervisionLn);
 }
 
 /** @returns Whether other subscribed ExtRef of the same control block exist */
@@ -111,7 +87,7 @@ function isControlBlockSubscribed(extRefs: Element[]): boolean {
 function cannotRemoveSupervision(extRefGroup: GroupedExtRefs): boolean {
   return (
     isControlBlockSubscribed(extRefGroup.extRefs) ||
-    !isSrcRefEditable(extRefGroup.ctrlBlock, extRefGroup.subscriberIed)
+    !isSupervisionEditable(extRefGroup.ctrlBlock, extRefGroup.subscriberIed)
   );
 }
 

--- a/tLN/supervision/foundation.ts
+++ b/tLN/supervision/foundation.ts
@@ -66,3 +66,38 @@ export function globalLnInstGenerator(): (
     return lnInstGenerators.get(iedName)!(lnClass);
   };
 }
+
+/** @returns Whether child `DA` with name `setSrcRef` can edited by SCL editor */
+export function isSrcRefEditable(supervisionLn: Element): boolean {
+  const lnClass = supervisionLn.getAttribute("lnClass");
+  const cbRefType = lnClass === "LGOS" ? "GoCBRef" : "SvCBRef";
+
+  if (
+    supervisionLn.querySelector(
+      `:scope > DOI[name="${cbRefType}"] > 
+        DAI[name="setSrcRef"][valImport="true"][valKind="RO"],
+       :scope > DOI[name="${cbRefType}"] > 
+        DAI[name="setSrcRef"][valImport="true"][valKind="Conf"]`,
+    )
+  )
+    return true;
+
+  const rootNode = supervisionLn.ownerDocument;
+  const lnType = supervisionLn.getAttribute("lnType");
+
+  const goOrSvCBRef = rootNode.querySelector(
+    `DataTypeTemplates > 
+        LNodeType[id="${lnType}"][lnClass="${lnClass}"] > DO[name="${cbRefType}"]`,
+  );
+
+  const cbRefId = goOrSvCBRef?.getAttribute("type");
+  const setSrcRef = rootNode.querySelector(
+    `DataTypeTemplates > DOType[id="${cbRefId}"] > DA[name="setSrcRef"]`,
+  );
+
+  return (
+    (setSrcRef?.getAttribute("valKind") === "Conf" ||
+      setSrcRef?.getAttribute("valKind") === "RO") &&
+    setSrcRef.getAttribute("valImport") === "true"
+  );
+}

--- a/tLN/supervision/removeSupervision.spec.ts
+++ b/tLN/supervision/removeSupervision.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import { supervision } from "./supervision.testfiles";
+import { removeSupervision } from "./removeSupervision";
+
+const doc = new DOMParser().parseFromString(supervision, "application/xml");
+
+describe("Function to remove an existing supervision from an supervision LN", () => {
+  it("does not remove when valImport/valKind check fails", () => {
+    const supervisionLn = doc.querySelector(
+      'IED[name="SupervisionNotSupported"] LN[lnClass="LGOS"]',
+    )!;
+
+    expect(removeSupervision(supervisionLn)).to.be.null;
+  });
+
+  it("does not remove when an subscription does exist", () => {
+    const supervisionLn = doc.querySelector(
+      'IED[name="GOOSE_Subscriber4"] LN[lnClass="LGOS"]',
+    )!;
+
+    expect(removeSupervision(supervisionLn)).to.be.null;
+  });
+
+  it("allows to disable the check for existing subscription of the supervision", () => {
+    const supervisionLn = doc.querySelector(
+      'IED[name="GOOSE_Subscriber4"] LN[lnClass="LGOS"]',
+    )!;
+
+    expect(
+      removeSupervision(supervisionLn, {
+        removeSupervisionLn: false,
+        checkSubscription: false,
+      }),
+    ).to.not.be.null;
+  });
+
+  it("does not remove when there is no supervision Val", () => {
+    const supervisionLn = doc.querySelector(
+      'IED[name="GOOSE_Subscriber3"] LN[lnClass="LGOS"][inst="3"]',
+    )!;
+
+    expect(removeSupervision(supervisionLn)).to.be.null;
+  });
+
+  it("per default empties control block object reference", () => {
+    const supervisionLn = doc.querySelector(
+      'IED[name="GOOSE_Subscriber3"] LN[lnClass="LGOS"][inst="4"]',
+    )!;
+
+    const removeEdit = removeSupervision(supervisionLn);
+    expect(removeEdit).to.not.be.null;
+    expect(removeEdit!.node.nodeType).to.equal(3);
+  });
+
+  it("per default empties control block object reference", () => {
+    const supervisionLn = doc.querySelector(
+      'IED[name="GOOSE_Subscriber3"] LN[lnClass="LGOS"][inst="4"]',
+    )!;
+
+    const removeEdit = removeSupervision(supervisionLn, {
+      removeSupervisionLn: true,
+      checkSubscription: true,
+    });
+    expect(removeEdit).to.not.be.null;
+    expect(removeEdit!.node.nodeType).to.equal(1);
+    expect((removeEdit!.node as Element).tagName).to.equal("LN");
+  });
+});

--- a/tLN/supervision/removeSupervision.ts
+++ b/tLN/supervision/removeSupervision.ts
@@ -1,0 +1,68 @@
+import { Remove } from "../../foundation/utils.js";
+import { isSrcRefEditable } from "./foundation.js";
+
+export type removeSupervisionOptions = {
+  removeSupervisionLn: boolean;
+  checkSubscription: boolean;
+};
+
+/** @returns Whether other subscribed ExtRef of the same control block exist */
+function isControlBlockSubscribed(supervisionLn: Element): boolean {
+  const controlObjRef = supervisionLn.querySelector(
+    `:scope > DOI[name="GoCBRef"] > DAI[name="setSrcRef"] > Val, 
+    :scope > DOI[name="SvCBRef"] > DAI[name="setSrcRef"] > Val`
+  )?.textContent;
+
+  const extRefs = Array.from(
+    supervisionLn.closest("IED")!.querySelectorAll(
+      `:scope > AccessPoint > Server > LDevice > LN0 > Inputs > ExtRef, 
+      :scope > AccessPoint > Server > LDevice > LN0 > Inputs > ExtRef`
+    )
+  );
+
+  return extRefs.some((extRef) => {
+    const [srcCBName, srcLDInst, iedName] = [
+      "srcCBName",
+      "srcLDInst",
+      "iedName",
+    ].map((attr) => extRef.getAttribute(attr));
+
+    return controlObjRef === `${iedName}${srcLDInst}/LLN0.${srcCBName}`;
+  });
+}
+
+export function canRemoveSupervision(
+  supervisionLn: Element,
+  options: removeSupervisionOptions
+): boolean {
+  if (!isSrcRefEditable(supervisionLn)) return false;
+
+  if (options.checkSubscription && isControlBlockSubscribed(supervisionLn))
+    return false;
+
+  return true;
+}
+
+export function removeSupervision(
+  supervisionLn: Element,
+  options: removeSupervisionOptions = {
+    removeSupervisionLn: false,
+    checkSubscription: true,
+  }
+): Remove | null {
+  if (!canRemoveSupervision(supervisionLn, options)) return null;
+
+  if (options.removeSupervisionLn) return { node: supervisionLn };
+
+  const val = supervisionLn.querySelector(
+    `:scope > DOI[name="GoCBRef"] > DAI[name="setSrcRef"] > Val, 
+    :scope > DOI[name="SvCBRef"] > DAI[name="setSrcRef"] > Val`
+  );
+  if (!val) return null;
+
+  const node = Array.from(val.childNodes).find(
+    (childNode) => childNode.nodeType === Node.TEXT_NODE
+  )!;
+
+  return { node };
+}

--- a/tLN/supervision/supervision.testfiles.ts
+++ b/tLN/supervision/supervision.testfiles.ts
@@ -6,8 +6,20 @@ export const supervision = `<SCL xmlns="http://www.iec.ch/61850/2003/SCL" versio
           <LDevice inst="Earth_Switch">
             <LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0" />
             <LN prefix="" lnClass="CSWI" inst="1" lnType="Dummy.CSWI" />
-            <LN lnClass="LGOS" lnType="Dummy.LGOS2" />
-            <LN lnClass="LSVS" lnType="Dummy.LSVS2" />
+            <LN lnClass="LGOS" lnType="Dummy.LGOS2" >
+              <DOI name="GoCBRef">
+                <DAI name="setSrcRef">
+                  <Val>PublisherGOOSE/LLN0.GOOSE1</Val>
+                </DAI>
+              </DOI>
+            </LN>
+            <LN lnClass="LSVS" lnType="Dummy.LSVS2" >
+              <DOI name="SvCBRef">
+                <DAI name="setSrcRef">
+                  <Val>PublisherSampledValue/LLN0.SMV1</Val>
+                </DAI>
+              </DOI>
+            </LN>
           </LDevice>
         </Server>
       </AccessPoint>


### PR DESCRIPTION
Closes #18 

I did create a new function as the name does more explain the function. Compared to `removeSubscriptionSupervision` here no supervision of a subscription is removed but rather the supervision directly. The two options allow to configure the function to individual needs.

@danyill I would be happy for a review.