### PR TITLE
fix(tExtRef): allow LLN0 as default srcLNClass (closes #85).

### DIFF
--- a/tExtRef/matchSrcAttributes.spec.ts
+++ b/tExtRef/matchSrcAttributes.spec.ts
@@ -60,6 +60,45 @@ describe("matchSrcAttributes", () => {
     expect(matchSrcAttributes(extRef, gse)).to.equal(true);
   });
 
+  it("allows LN0 as parent when srcLNClass is undefined", () => {
+    extRef.removeAttribute("srcPrefix");
+    extRef.removeAttribute("srcLNClass");
+
+    LDevice.appendChild(ln0);
+    ln0.appendChild(gse);
+
+    expect(matchSrcAttributes(extRef, gse)).to.equal(true);
+  });
+
+  it("is insensitive to empty string srcLNClass", () => {
+    extRef.setAttribute("srcLNClass", "");
+
+    LDevice.appendChild(ln0);
+    ln0.appendChild(gse);
+
+    expect(matchSrcAttributes(extRef, gse)).to.equal(true);
+  });
+
+  it("it uses ldInst when srcLDInst is undefined", () => {
+    extRef.removeAttribute("srcLDInst", "");
+    extRef.setAttribute("ldInst", "ldInst");
+
+    LDevice.appendChild(ln0);
+    ln0.appendChild(gse);
+
+    expect(matchSrcAttributes(extRef, gse)).to.equal(true);
+  });
+
+  it("is insensitive to empty string srcLDInst", () => {
+    extRef.setAttribute("srcLDInst", "");
+    extRef.setAttribute("ldInst", "ldInst");
+
+    LDevice.appendChild(ln0);
+    ln0.appendChild(gse);
+
+    expect(matchSrcAttributes(extRef, gse)).to.equal(true);
+  });
+
   it("is insensitive to null inst", () => {
     ln0.setAttribute("inst", "");
     extRef.setAttribute("srcLNInst", "");

--- a/tExtRef/matchSrcAttributes.ts
+++ b/tExtRef/matchSrcAttributes.ts
@@ -12,12 +12,24 @@ export function matchSrcAttributes(extRef: Element, control: Element): boolean {
   const srcLNClass = control.closest("LN0, LN")?.getAttribute("lnClass");
   const srcLNInst = control.closest("LN0, LN")?.getAttribute("inst");
 
+  const extRefSrcLNClass = extRef.getAttribute("srcLNClass");
+  const srcLnClassCheck =
+    !extRefSrcLNClass || extRefSrcLNClass === ""
+      ? "LLN0" === srcLNClass
+      : extRefSrcLNClass === srcLNClass;
+
+  const extRefSrcLDInst = extRef.getAttribute("srcLDInst");
+  const srcLdInstCheck =
+    !extRefSrcLDInst || extRefSrcLDInst === ""
+      ? extRef.getAttribute("ldInst") === srcLDInst
+      : extRefSrcLDInst === srcLDInst;
+
   return (
     extRef.getAttribute("srcCBName") === cbName &&
-    extRef.getAttribute("srcLDInst") === srcLDInst &&
+    srcLdInstCheck &&
     (extRef.getAttribute("srcPrefix") ?? "") === srcPrefix &&
     (extRef.getAttribute("srcLNInst") ?? "") === srcLNInst &&
-    extRef.getAttribute("srcLNClass") === srcLNClass &&
+    srcLnClassCheck &&
     extRef.getAttribute("serviceType") === serviceType[control.tagName]
   );
 }


### PR DESCRIPTION
Closes #85 but also a bit of a drive by improvement:

* Also allow `srcLNClass` and `srcLDInst` to be empty when choosing fallbacks.
* Allow `ldInst` to be used if `srcLDInst` is not defined.

This is as per Table 33 of IEC 61850-6 Ed 2.1.

I shall be happy to receive a review and make improvements.
