### PR TITLE
feat(tExtRef): export matchDataAttributes and matchSrcAttributes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -52,6 +52,8 @@ export { macAddressGenerator } from "./generator/macAddressGenerator.js";
 export { appIdGenerator } from "./generator/appIdGenerator.js";
 export { lnInstGenerator } from "./generator/lnInstGenerator.js";
 
+export { matchDataAttributes } from "./tExtRef/matchDataAttributes.js";
+export { matchSrcAttributes } from "./tExtRef/matchSrcAttributes.js";
 export { UnsubscribeOptions } from "./tExtRef/unsubscribe.js";
 export { unsubscribe } from "./tExtRef/unsubscribe.js";
 export { Connection } from "./tExtRef/subscribe.js";


### PR DESCRIPTION
Closes #87 

I thought there was no obvious reason to only export `matchSrcAttributes` so I've also exported `matchDataAttributes`.

I'll be happy to receive a review and make further changes.