### PR TITLE
fix(tIED/removeIED): Retain ldInst in LNodes when removing an IED

### DIFF
--- a/tIED/removeIED.ts
+++ b/tIED/removeIED.ts
@@ -58,7 +58,7 @@ function updateIedNameToNone(ied: Element, iedName: string): Update[] {
   return Array.from(ied.ownerDocument.querySelectorAll(selector))
     .filter(isPublic)
     .map((element) => {
-      return { element, attributes: { iedName: "None", ldInst: null } };
+      return { element, attributes: { iedName: "None" } };
     });
 }
 


### PR DESCRIPTION
Closes #96.

This doesn't affect the tests because we just checked that an Upate edit occurs on the LNode, not the contents of it.


