### PR TITLE
fix(tLN): Make supervision removal only remove Val textContent

### DIFF
--- a/tDataSet/removeDataSet.spec.ts
+++ b/tDataSet/removeDataSet.spec.ts
@@ -18,15 +18,15 @@ describe("Utility function to remove DataSet element", () => {
       'ExtRef[srcCBName="someGse"], ExtRef[srcCBName="someGse2"], ExtRef[srcCBName="someGse3"]',
     ),
   );
-  const doi = extRefs[0].ownerDocument.querySelector(
-    'LN[lnClass="LGOS"][inst="1"] > DOI',
+  const val = extRefs[0].ownerDocument.querySelector(
+    'LN[lnClass="LGOS"][inst="1"] > DOI[name="GoCBRef"] > DAI[name="setSrcRef"] > Val',
   )!;
   const ln = extRefs[0].ownerDocument.querySelector(
     'LN[lnClass="LGOS"][inst="2"]',
   );
 
   it("returns empty string when remove.node is not DataSet", () =>
-    expect(removeDataSet({ node: doi })).to.be.empty);
+    expect(removeDataSet({ node: val })).to.be.empty);
 
   it("removes DataSet also removes/updates dependant data", () =>
     expect(edits.length).to.equal(10));
@@ -42,7 +42,7 @@ describe("Utility function to remove DataSet element", () => {
   });
 
   it("including the subscriber supervision", () => {
-    expect((edits[5] as Remove).node).to.equal(doi);
+    expect((edits[5] as Remove).node).to.equal(val.firstChild);
     expect((edits[6] as Remove).node).to.equal(ln);
   });
 

--- a/tExtRef/unsubscribe.spec.ts
+++ b/tExtRef/unsubscribe.spec.ts
@@ -92,8 +92,8 @@ describe("Function allowing to unsubscribe multiple external references", () => 
       'ExtRef[srcCBName="someGse"], ExtRef[srcCBName="someGse2"]',
     );
     const edits = unsubscribe(extRefs);
-    const doi = extRefs[0].ownerDocument.querySelector(
-      'LN[lnClass="LGOS"][inst="1"] > DOI',
+    const val = extRefs[0].ownerDocument.querySelector(
+      'LN[lnClass="LGOS"][inst="1"] > DOI[name="GoCBRef"] > DAI[name="setSrcRef"] > Val',
     );
     const ln = extRefs[0].ownerDocument.querySelector(
       'LN[lnClass="LGOS"][inst="2"]',
@@ -107,7 +107,7 @@ describe("Function allowing to unsubscribe multiple external references", () => 
     expect(edits[2]).to.satisfies(isUpdate);
     expect((edits[2] as Update).element).to.equal(extRefs[2]);
     expect(edits[3]).to.satisfies(isRemove);
-    expect((edits[3] as Remove).node).to.equal(doi);
+    expect((edits[3] as Remove).node).to.equal(val.firstChild);
     expect(edits[4]).to.satisfies(isRemove);
     expect((edits[4] as Remove).node).to.equal(ln);
   });
@@ -157,8 +157,8 @@ describe("Function allowing to unsubscribe multiple external references", () => 
       withSubscriptionSupervision,
       'ExtRef[srcCBName="someSmv"]',
     );
-    const doi = extRefs[0].ownerDocument.querySelector(
-      'LN[lnClass="LSVS"][inst="1"] > DOI',
+    const val = extRefs[0].ownerDocument.querySelector(
+      'LN[lnClass="LSVS"][inst="1"] > DOI[name="SvCBRef"] > DAI[name="setSrcRef"] > Val',
     );
     const edits = unsubscribe(extRefs);
 
@@ -170,7 +170,7 @@ describe("Function allowing to unsubscribe multiple external references", () => 
     expect(edits[2]).to.satisfies(isRemove);
     expect((edits[2] as Remove).node).to.equal(extRefs[1].parentElement);
     expect(edits[3]).to.satisfies(isRemove);
-    expect((edits[3] as Remove).node).to.equal(doi);
+    expect((edits[3] as Remove).node).to.equal(val!.firstChild);
   });
 
   it("with ignoreSupervision do not remove subscription LGOS supervision", () => {


### PR DESCRIPTION
Closes #129 

This PR makes supervision removal do the most minimal thing possible and seems to me to be the best way of reading the standard. It also fixes an issue where an ICT tool cannot function with our present behaviour.