### PR TITLE
fix: improve test coverage, remove scope guards

### DIFF
--- a/tIED/removeIED.spec.ts
+++ b/tIED/removeIED.spec.ts
@@ -53,6 +53,12 @@ describe("Function to an remove the IED and its referenced elements", () => {
     expect(numberRemoves(edits, "LNode")).to.equal(1);
   });
 
+  it("returns empty LNode edits for an IED without substation LNodes with preserveLNodes option", () => {
+    const edits = removeIED({ node: client }, { preserveLNodes: true });
+    expect(numberRemoves(edits, "LNode")).to.equal(0);
+    expect(numberUpdates(edits, "LNode")).to.equal(0);
+  });
+
   it("removes ConnectedAPs as well", () => {
     const edits = removeIED({ node: publisher });
 
@@ -149,7 +155,7 @@ describe("Function to an remove the IED and its referenced elements", () => {
           const edits = removeIED({ node: iedA });
           handleEdit(edits);
           const after_iedA_lNodes = Array.from(
-            sclDom.querySelectorAll(`${scope} LNode[iedName="IED_A"]`),
+            sclDom.querySelectorAll(`${scope} > LNode[iedName="IED_A"]`),
           ).length;
           const after_spec_LNodeCount = (
             sclDom.querySelectorAll(`${scope} > LNode[iedName='None']`) ?? []
@@ -158,18 +164,20 @@ describe("Function to an remove the IED and its referenced elements", () => {
           // The number of LNodes set to None should not have changed.
           expect(after_spec_LNodeCount).to.equal(beforeSpec_LNodeCount);
 
-          const privateLNodeCount = sclDom.querySelectorAll(`${scope} > Private > LNode[iedName='IED_A']`).length;
-          expect(privateLNodeCount).to.equal(1, 'Private LNode count is wrong');
+          const privateLNodeCount = sclDom.querySelectorAll(
+            `${scope} > Private > LNode[iedName='IED_A']`,
+          ).length;
+          expect(privateLNodeCount).to.equal(1, "Private LNode count is wrong");
         });
       });
     });
 
-    describe.only("with preserveLNodes set", () => {
+    describe("with preserveLNodes set", () => {
       // Broke this into 3 separate tests, so the scope of the failure "might" be narrower.
       // Do keep in mind however, the subject SCL has 2 of everything. E.g. S1 & S2
       ["Bay", "VoltageLevel", "Substation"].forEach((scope) => {
         it(`Within a ${scope}, it sets all bound LNodes to None`, () => {
-          //We're using the "duplicates" test file, but by only deleting 1 IED, no duplicates occur (yet).
+          // We're using the "duplicates" test file, but by only deleting 1 IED, no duplicates occur (yet).
           const sclDom = new DOMParser().parseFromString(
             sclDuplicateLNodes,
             "application/xml",

--- a/tIED/removeIED.testfile.ts
+++ b/tIED/removeIED.testfile.ts
@@ -582,6 +582,9 @@ export const scl = `<SCL xmlns="http://www.iec.ch/61850/2003/SCL" xmlns:esld="ht
 export const sclDuplicateLNodes = `<SCL xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B" release="4">
 <Header id="DuplicateLNodes"/>
 <Substation name="S1">
+  <Private type="eieio">
+      <LNode iedName="IED_A" ldInst="CBSW" lnClass="XCBR" lnInst="1" prefix=""/>
+    </Private>
   <LNode iedName="IED_A" ldInst="CBSW" lnClass="XCBR" lnInst="1" prefix=""/>
   <LNode iedName="IED_B" ldInst="CBSW" lnClass="XCBR" lnInst="1" prefix=""/>
   <VoltageLevel name="V1">
@@ -591,6 +594,9 @@ export const sclDuplicateLNodes = `<SCL xmlns="http://www.iec.ch/61850/2003/SCL"
     <LNode iedName="IED_A" ldInst="CBSW" lnClass="XCBR" lnInst="1" prefix=""/>
     <LNode iedName="IED_B" ldInst="CBSW" lnClass="XCBR" lnInst="1" prefix=""/>
     <Bay name="B1">
+      <Private type="eieio">
+        <LNode iedName="IED_A" ldInst="CBSW" lnClass="XCBR" lnInst="1" prefix=""/>
+      </Private>
       <LNode iedName="IED_A" ldInst="CBSW" lnClass="XCBR" lnInst="1" prefix=""/>
       <LNode iedName="IED_B" ldInst="CBSW" lnClass="XCBR" lnInst="1" prefix=""/>
       <ConductingEquipment name="QA1" type="CBR">

--- a/tIED/removeIED.ts
+++ b/tIED/removeIED.ts
@@ -51,11 +51,8 @@ function removeIedSubscriptionsAndSupervisions(
 const lNodeKey = (ln: Element): string =>
   ["lnClass", "lnInst", "ldInst", "prefix"].map((a) => ln.getAttribute(a) ?? "").join("|");
 
-const getLNodeScopeElement = (ln: Element): Element | null => {
-  if (ln.closest("Private") === null) {
-    return ln.closest("Bay, VoltageLevel, Substation");
-  }
-  return null;
+const getLNodeScopeElement = (ln: Element): Element => {
+  return ln.closest("Bay, VoltageLevel, Substation")!;
 };
 
 const createRemoveEdit = (ln: Element): Remove => {
@@ -68,7 +65,7 @@ const setLNodeToNone = (ln: Element): SetAttributes => {
 
 const getLNodesByIedName = (doc: XMLDocument, name: string): Element[] => {
   return Array.from(
-    doc.querySelectorAll(`Substation LNode[iedName=${name}]`) ?? [],
+    doc.querySelectorAll(`Substation LNode[iedName=${name}]`),
   ).filter(isPublic);
 };
 
@@ -76,7 +73,7 @@ const getLNodesByIedName = (doc: XMLDocument, name: string): Element[] => {
  * Default handling for LNodes - find any (public) matching LNodes and create a Remove edit for them.
  */
 function removeBoundLNodes(ied: Element, name: string): Remove[] {
-  return (getLNodesByIedName(ied.ownerDocument, name) ?? []).map(createRemoveEdit);
+  return (getLNodesByIedName(ied.ownerDocument, name)).map(createRemoveEdit);
 }
 
 /**
@@ -101,23 +98,17 @@ function detachLNodeBindings(
   const unboundLNodesByScope = new Map<Element, Set<string>>();
   getLNodesByIedName(doc, "None").forEach((ln) => {
     const scope = getLNodeScopeElement(ln);
-    if (scope !== null) {
-      let keys = unboundLNodesByScope.get(scope);
-      if (!keys) {
-        keys = new Set<string>();
-        unboundLNodesByScope.set(scope, keys);
-      }
-      keys.add(lNodeKey(ln));
+    let keys = unboundLNodesByScope.get(scope);
+    if (!keys) {
+      keys = new Set<string>();
+      unboundLNodesByScope.set(scope, keys);
     }
+    keys.add(lNodeKey(ln));
   });
 
   return boundNodes
     .map((ln) => {
       const scope = getLNodeScopeElement(ln);
-      if (!scope) {
-        return;
-      }
-
       const keys = unboundLNodesByScope.get(scope);
 
       const key = lNodeKey(ln);


### PR DESCRIPTION
Some small simplifications:

* Remove `describe.only` to run test suite and then fix treatment of `Private` elements.
* Remove scope test. We can assume our SCL file is valid and it's not testable.
* Remove nullish array coalescing, we never need this for these cases.
* Remove `Private` check, we never need this because we have already filtered out `Private` elements.

I'm just getting back to scl-lib after a hiatus so I'm not intending to be especially pedantic, so sorry if this is a bit annoying :crying_cat_face: 

These changes bring our test coverage for `removeIED.ts` up to :100:% 